### PR TITLE
Add Greasemonkey support

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -14,10 +14,22 @@
 // @downloadURL https://github.com/Anarios/return-youtube-dislike/raw/main/Extensions/UserScript/Return%20Youtube%20Dislike.user.js
 // @updateURL https://github.com/Anarios/return-youtube-dislike/raw/main/Extensions/UserScript/Return%20Youtube%20Dislike.user.js
 // @grant GM_xmlhttpRequest
+// @grant GM.xmlHttpRequest
 // ==/UserScript==
 function cLog(text, subtext = '') {
   subtext = subtext.trim() === '' ? '' : `(${subtext})`;
   console.log(`[Return Youtube Dislikes] ${text} ${subtext}`);
+}
+
+function doXHR(opts) {
+  if (typeof GM_xmlhttpRequest === 'function') {
+    return GM_xmlhttpRequest(opts);
+  }
+  if (typeof GM.xmlHttpRequest === 'function') {
+    return GM.xmlHttpRequest(opts);
+  }
+
+  console.error('Unable to detect UserScript plugin.');
 }
 
 function getButtons() {
@@ -72,7 +84,7 @@ function setDislikes(dislikesCount) {
 function setState() {
   cLog('Fetching votes...');
 
-  GM_xmlhttpRequest({
+  doXHR({
     method: "GET",
     responseType: "json",
     url:


### PR DESCRIPTION
First, thanks for creating this script/extension!

I installed the Userscript in Greasemonkey but, while the script ran, it would stop at the call to `GM_xmlhttpRequest` which apparently isn't available in GM.

Changing it to `GM.xmlHttpRequest(...)` got everything working great (after adding some logging to track the issue down, so I've included that to help find future glitches) so this PR adds it as a fallback in case the `GM_` variant can't be found.

As far as I can tell, `GM_` is available in both Tampermonkey and Violentmonkey. Although they seem to alias the `GM.` variant, I've kept both in case that's missing in some versions or other compatible plugins I'm unaware of.

Tried in both Firefox and Chrome on Linux with {Grease,Tamper,Violent}Monkey.