### PR TITLE
Fix for locales separating decimals with commas

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -209,7 +209,7 @@ function numberFormat(numberState) {
     maximumFractionDigits: 1
   });
 
-  return formatter.format(roundDown(numberState)).replace('.0', '');
+  return formatter.format(roundDown(numberState)).replace(/.0|,0/gi, '');
 }
 
 function setEventListeners(evt) {

--- a/Extensions/chrome/return-youtube-dislike.script.js
+++ b/Extensions/chrome/return-youtube-dislike.script.js
@@ -154,7 +154,7 @@
       maximumFractionDigits: 1
     });
 
-    return formatter.format(roundDown(numberState)).replace('.0', '');
+    return formatter.format(roundDown(numberState)).replace(/.0|,0/gi, '');
   }
 
   var jsInitChecktimer = null;

--- a/Extensions/firefox/return-youtube-dislike.script.js
+++ b/Extensions/firefox/return-youtube-dislike.script.js
@@ -150,7 +150,7 @@ function numberFormat(numberState) {
     maximumFractionDigits: 1
   });
 
-  return formatter.format(roundDown(numberState)).replace('.0', '');
+  return formatter.format(roundDown(numberState)).replace(/.0|,0/gi, '');
 }
 
 function setEventListeners(evt) {


### PR DESCRIPTION
Some locales use a comma to separate decimals instead of a period. In these locales the number of dislikes is incorrectly shown:
<img width="181" alt="image" src="https://user-images.githubusercontent.com/39172206/143787906-947981ca-f2e7-47d4-b27e-cfb9d1ccaaf3.png">

This fix adds a simple regex to a str.replace