### PR TITLE
Fix typos

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -16,7 +16,7 @@
 // ==/UserScript==
 function cLog(text, subtext = '') {
   subtext = subtext.trim() === '' ? '' : `(${subtext})`;
-  console.log(`[Return Youtube Dislikes] ${text} ${subtext}`);
+  console.log(`[Return YouTube Dislikes] ${text} ${subtext}`);
 }
 
 function doXHR(opts) {

--- a/Extensions/chrome/popup.html
+++ b/Extensions/chrome/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta content="text/html; charset=utf-8">
-    <title>Return Youtube Dislike</title>
+    <title>Return YouTube Dislike</title>
     <link rel="stylesheet" href="popup.css">
   </head>
   <body>
@@ -10,11 +10,11 @@
 
     <center>
       <img src="icons/icon48.png" alt="Logo" />
-      <h1>Return Youtube Dislike</h1>
+      <h1>Return YouTube Dislike</h1>
       <p>by Dmitrii Selivanov & Community</p>
 
       <button id="link_website">Website</button>
-      <button id="link_github">Github</button>
+      <button id="link_github">GitHub</button>
       <button id="link_discord">Discord</button>
 
       <br>

--- a/Extensions/firefox/manifest.json
+++ b/Extensions/firefox/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Return Youtube Dislike",
+  "name": "Return YouTube Dislike",
   "description": "Returns ability to see dislikes",
   "version": "0.0.0.9",
   "manifest_version": 2,

--- a/Extensions/firefox/popup.html
+++ b/Extensions/firefox/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta content="text/html; charset=utf-8">
-    <title>Return Youtube Dislike</title>
+    <title>Return YouTube Dislike</title>
     <link rel="stylesheet" href="popup.css">
   </head>
   <body>
@@ -10,11 +10,11 @@
 
     <center>
       <img src="icons/icon48.png" alt="Logo" />
-      <h1>Return Youtube Dislike</h1>
+      <h1>Return YouTube Dislike</h1>
       <p>by Dmitrii Selivanov & Community</p>
 
       <button id="link_website">Website</button>
-      <button id="link_github">Github</button>
+      <button id="link_github">GitHub</button>
       <button id="link_discord">Discord</button>
 
       <br>

--- a/StaticSiteOld/index.html
+++ b/StaticSiteOld/index.html
@@ -171,7 +171,7 @@
             extension users to derive actual dislike count on a video
           </p>
           <p>
-            Youtube has removed dislike statistics. Since this was a very
+            YouTube has removed dislike statistics. Since this was a very
             usefull feature - this extension aims to return this functionality
             to users.
           </p>
@@ -181,7 +181,7 @@
           </div>
           <p>
             We're considering integration with
-            <a href="https://vancedapp.com/">Youtube Vanced</a> mobile app, if
+            <a href="https://vancedapp.com/">YouTube Vanced</a> mobile app, if
             the devs will want to utilize our API
           </p>
 

--- a/Website/README.md
+++ b/Website/README.md
@@ -1,4 +1,4 @@
-# Return-Youtube-Dislike
+# return-youtube-dislike-site
 
 ## Build Setup
 

--- a/Website/nuxt.config.js
+++ b/Website/nuxt.config.js
@@ -3,8 +3,8 @@ import colors from 'vuetify/es5/util/colors'
 export default {
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
-    titleTemplate: 'Return Youtube Dislike',
-    title: 'Return Youtube Dislike',
+    titleTemplate: 'Return YouTube Dislike',
+    title: 'Return YouTube Dislike',
     htmlAttrs: {
       lang: 'en'
     },

--- a/Website/pages/index.vue
+++ b/Website/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
 
-    <h1 style="font-size: 3em; margin-bottom:0;">Return Youtube Dislike</h1>
+    <h1 style="font-size: 3em; margin-bottom:0;">Return YouTube Dislike</h1>
     <div style="color: #999">
       <p style="margin-top: 0">Browser extension and an API that show you dislikes on youtube</p>
     </div>
@@ -15,7 +15,7 @@
 
     <v-btn class="mainAltButton" :href="githubLink" target="_blank">
       <v-icon style="margin-right: 0.5em;">mdi-github</v-icon>
-      Github
+      GitHub
     </v-btn>
 
     <v-btn class="mainAltButton" :href="discordLink" target="_blank">

--- a/Website/pages/links.vue
+++ b/Website/pages/links.vue
@@ -9,7 +9,7 @@
 
     <v-btn class="mainAltButton" :href="githubLink" target="_blank">
       <v-icon style="margin-right: 0.5em;">mdi-github</v-icon>
-      Github
+      GitHub
     </v-btn>
 
     <v-btn class="mainAltButton" :href="discordLink" target="_blank">


### PR DESCRIPTION
Thank you so much for this project! 👍 

Just a couple of typo/capitalization fixes here:

- `Github` -> `GitHub`
- `Youtube` -> `YouTube`