### PR TITLE
Enhancement: Add Opera/Edge links to Install Page

### DIFF
--- a/Website/pages/install.vue
+++ b/Website/pages/install.vue
@@ -5,8 +5,13 @@
 
     <div style="color: #999">
       <p style="margin-bottom: 0;"> This is an <b>ALPHA version!</b> It may be slow. It may be buggy.</p>
-      <p style="margin-bottom: 3em;">Only available for Chrome, Firefox and as a Userscript now, but coming to other platforms soon.</p>
+      <p style="margin-bottom: 1em;">Available for Firefox and all Chromium browsers (Chrome/Edge/Opera/Brave).</p>
     </div>
+
+    <v-btn class="mainAltButton" :href="firefoxLink" target="_blank">
+      <v-icon style="margin-right: 0.5em;">mdi-firefox</v-icon>
+      Firefox
+    </v-btn>
 
     <v-btn class="mainAltButton" :href="chromeLink" target="_blank">
       <v-icon style="margin-right: 0.5em;">mdi-google-chrome</v-icon>
@@ -22,11 +27,11 @@
       <v-icon style="margin-right: 0.5em;">mdi-opera</v-icon>
       Opera
     </v-btn>
-    <v-btn class="mainAltButton" :href="firefoxLink" target="_blank">
-      <v-icon style="margin-right: 0.5em;">mdi-firefox</v-icon>
-      Firefox
-    </v-btn>
-    <br><br>
+
+    <h3 style="margin-top: 3em; margin-bottom:0">Other Platforms</h3>
+    <div style="color: #999">
+      <p style="margin-top: 0em; margin-bottom:0;">If your browser is not yet supported, try this UserScript.</p>
+    </div>
 
     <v-btn class="mainAltButton" :href="scriptLink" target="_blank">
       <v-icon style="margin-right: 0.5em;">mdi-script-text-outline</v-icon>
@@ -35,7 +40,7 @@
 
     <h3 style="margin-top: 3em;">Third Party Implementations</h3>
     <div style="color: #999">
-      <p style="margin-bottom: 0;">No liability on our side, use at your own risk</p>
+      <p style="margin-bottom: 0;">No liability on our side, use at your own risk.</p>
     </div>
     <v-btn class="mainAltButton" :href="iosJailbreakLink" target="_blank">
       <v-icon style="margin-right: 0.5em;">mdi-apple</v-icon>

--- a/Website/pages/install.vue
+++ b/Website/pages/install.vue
@@ -13,10 +13,20 @@
       Chrome
     </v-btn>
 
+    <v-btn class="mainAltButton" :href="chromeLink" target="_blank">
+      <v-icon style="margin-right: 0.5em;">mdi-microsoft-edge</v-icon>
+      Edge
+    </v-btn>
+
+    <v-btn class="mainAltButton" :href="chromeLink" target="_blank">
+      <v-icon style="margin-right: 0.5em;">mdi-opera</v-icon>
+      Opera
+    </v-btn>
     <v-btn class="mainAltButton" :href="firefoxLink" target="_blank">
       <v-icon style="margin-right: 0.5em;">mdi-firefox</v-icon>
       Firefox
     </v-btn>
+    <br><br>
 
     <v-btn class="mainAltButton" :href="scriptLink" target="_blank">
       <v-icon style="margin-right: 0.5em;">mdi-script-text-outline</v-icon>


### PR DESCRIPTION
Many users are unaware they can enable the Chrome web store extension on their Chromium browsers. This PR adds icons, links, and reformatting. The new Opera and Edge links point to the same Chrome web store but in a more intuitive manner for other Chromium browser users by indicating they work for Edge and Opera. 

Note: I couldn't find a material design icon for Brave (unfortunately it's not native to vuetify and would need to be included in a different icon set).

Here's the new install page. TL;DR The new Edge/Opera links go to compatible Chrome web store.
<img width="782" alt="Screen Shot 2021-12-01 at 1 28 20 AM" src="https://user-images.githubusercontent.com/79610204/144193538-6ef5b3b8-a35f-4c14-b9c6-ee376c1e6225.png">

