### PR TITLE
Bug fix(Issue #142)

### DIFF
--- a/Extensions/chrome/return-youtube-dislike.script.js
+++ b/Extensions/chrome/return-youtube-dislike.script.js
@@ -75,7 +75,7 @@
           cLog("response from youtube:");
           cLog(JSON.stringify(response));
           try {
-            if (response.likes || response.dislikes) {
+            if (response.likes >=0 || response.dislikes >=0) {
               const formattedDislike = numberFormat(response.dislikes);
               setDislikes(formattedDislike);
               createRateBar(response.likes, response.dislikes);

--- a/Extensions/firefox/return-youtube-dislike.script.js
+++ b/Extensions/firefox/return-youtube-dislike.script.js
@@ -71,7 +71,7 @@ function setState() {
         cLog("response from youtube:");
         cLog(JSON.stringify(response));
         try {
-          if (response.likes || response.dislikes) {
+          if (response.likes >=0  || response.dislikes >=0) {
             const formattedDislike = numberFormat(response.dislikes);
             setDislikes(formattedDislike);
             createRateBar(response.likes, response.dislikes);


### PR DESCRIPTION
Issue : Returning NAN instead of 0 for dislikes #142 
Changes:  `response.likes` or  `response.dislikes` if it is 0 then it will be interpreted as `false` and it won't reach the code to display the correct format.
