### PR TITLE
Style update in expansion panel on FAQ page

### DIFF
--- a/Website/pages/faq.vue
+++ b/Website/pages/faq.vue
@@ -8,7 +8,7 @@
     <v-expansion-panels focusable>
       <v-expansion-panel v-for="(item, i) in items" :key="i" style="width: 50vw; min-width: 300px;">
         <v-expansion-panel-header v-text="item.question">Loading</v-expansion-panel-header>
-        <v-expansion-panel-content v-html="item.answer" style="text-align: left; padding: 0.5em;">Loading</v-expansion-panel-content>
+        <v-expansion-panel-content v-html="item.answer" style="text-align: left; padding: 24px;">Loading</v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
 


### PR DESCRIPTION
Updated the padding in the answer sections of the FAQ page to be in line with the questions and give it some breathing room.

#### BEFORE
<img width="420" alt="before" src="https://user-images.githubusercontent.com/89289953/144589661-2872d6af-c3b5-4d3f-8045-a22fe0e0c2df.png">

#### AFTER
<img width="420" alt="after" src="https://user-images.githubusercontent.com/89289953/144589691-978db5d6-90fb-4629-a5c2-ea521012e8a3.png">


