### PR TITLE
Format dislikes the same way likes are formatted

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -213,32 +213,10 @@ function getVideoId() {
   return videoId;
 }
 
-function isVideoLoaded() {
-  const videoId = getVideoId();
-
-  return (
-    document.querySelector(`ytd-watch-flexy[video-id='${videoId}']`) !== null
-  );
-}
-
-function roundDown(num) {
-  if (num < 1000) return num;
-  const int = Math.floor(Math.log10(num) - 2);
-  const decimal = int + (int % 3 ? 1 : 0);
-  const value = Math.floor(num / 10 ** decimal);
-  return value * 10 ** decimal;
-}
-
-function numberFormat(numberState) {
-  const userLocales = navigator.language;
-
-  const formatter = Intl.NumberFormat(userLocales, {
-    notation: "compact",
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
-  });
-
-  return formatter.format(roundDown(numberState)).replace(/\.0|,0/, "");
+function numberFormat(num) {
+  const sign = [[1E6, "M"], [1E3, "K"],[1, ""]];
+  for (let i = 0; i <= sign.length; i++)
+     if (num >= sign[i][0]) return (num / sign[i][0]).toFixed(1).replace('.0', '') + sign[i][1];
 }
 
 function getDislikesFromYoutubeResponse(htmlResponse) {

--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -222,9 +222,14 @@ function isVideoLoaded() {
 }
 
 function numberFormat(num) {
-  const sign = [[1E6, "M"], [1E3, "K"],[1, ""]];
+  const sign = [
+    [1e6, "M"],
+    [1e3, "K"],
+    [1, ""],
+  ];
   for (let i = 0; i <= sign.length; i++)
-     if (num >= sign[i][0]) return (num / sign[i][0]).toFixed(1).replace('.0', '') + sign[i][1];
+    if (num >= sign[i][0])
+      return (num / sign[i][0]).toFixed(1).replace(".0", "") + sign[i][1];
 }
 
 function getDislikesFromYoutubeResponse(htmlResponse) {

--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -213,6 +213,14 @@ function getVideoId() {
   return videoId;
 }
 
+function isVideoLoaded() {
+  const videoId = getVideoId();
+
+  return (
+    document.querySelector(`ytd-watch-flexy[video-id='${videoId}']`) !== null
+  );
+}
+
 function numberFormat(num) {
   const sign = [[1E6, "M"], [1E3, "K"],[1, ""]];
   for (let i = 0; i <= sign.length; i++)

--- a/Extensions/chrome/return-youtube-dislike.script.js
+++ b/Extensions/chrome/return-youtube-dislike.script.js
@@ -166,9 +166,14 @@
   }
 
   function numberFormat(num) {
-    const sign = [[1E6, "M"], [1E3, "K"],[1, ""]];
+    const sign = [
+      [1e6, "M"],
+      [1e3, "K"],
+      [1, ""],
+    ];
     for (let i = 0; i <= sign.length; i++)
-       if (num >= sign[i][0]) return (num / sign[i][0]).toFixed(1).replace('.0', '') + sign[i][1];
+      if (num >= sign[i][0])
+        return (num / sign[i][0]).toFixed(1).replace(".0", "") + sign[i][1];
   }
 
   var jsInitChecktimer = null;

--- a/Extensions/chrome/return-youtube-dislike.script.js
+++ b/Extensions/chrome/return-youtube-dislike.script.js
@@ -165,22 +165,10 @@
     );
   }
 
-  function roundDown(num) {
-    if (num < 1000) return num;
-    const int = Math.floor(Math.log10(num) - 2);
-    const decimal = int + (int % 3 ? 1 : 0);
-    const value = Math.floor(num / 10 ** decimal);
-    return value * (10 ** decimal);
-  }
-
-  function numberFormat(numberState) {
-    const userLocales = navigator.language;
-
-    const formatter = Intl.NumberFormat(userLocales, {
-      notation: 'compact'
-    });
-
-    return formatter.format(roundDown(numberState));
+  function numberFormat(num) {
+    const sign = [[1E6, "M"], [1E3, "K"],[1, ""]];
+    for (let i = 0; i <= sign.length; i++)
+       if (num >= sign[i][0]) return (num / sign[i][0]).toFixed(1).replace('.0', '') + sign[i][1];
   }
 
   var jsInitChecktimer = null;

--- a/Extensions/firefox/return-youtube-dislike.script.js
+++ b/Extensions/firefox/return-youtube-dislike.script.js
@@ -151,22 +151,10 @@ function isVideoLoaded() {
   );
 }
 
-function roundDown(num) {
-  if (num < 1000) return num;
-  const int = Math.floor(Math.log10(num) - 2);
-  const decimal = int + (int % 3 ? 1 : 0);
-  const value = Math.floor(num / 10 ** decimal);
-  return value * 10 ** decimal;
-}
-
-function numberFormat(numberState) {
-  const userLocales = navigator.language;
-
-  const formatter = Intl.NumberFormat(userLocales, {
-    notation: "compact"
-  });
-
-  return formatter.format(roundDown(numberState));
+function numberFormat(num) {
+  const sign = [[1E6, "M"], [1E3, "K"],[1, ""]];
+  for (let i = 0; i <= sign.length; i++)
+     if (num >= sign[i][0]) return (num / sign[i][0]).toFixed(1).replace('.0', '') + sign[i][1];
 }
 
 function setEventListeners(evt) {

--- a/Extensions/firefox/return-youtube-dislike.script.js
+++ b/Extensions/firefox/return-youtube-dislike.script.js
@@ -152,9 +152,14 @@ function isVideoLoaded() {
 }
 
 function numberFormat(num) {
-  const sign = [[1E6, "M"], [1E3, "K"],[1, ""]];
+  const sign = [
+    [1e6, "M"],
+    [1e3, "K"],
+    [1, ""],
+  ];
   for (let i = 0; i <= sign.length; i++)
-     if (num >= sign[i][0]) return (num / sign[i][0]).toFixed(1).replace('.0', '') + sign[i][1];
+    if (num >= sign[i][0])
+      return (num / sign[i][0]).toFixed(1).replace(".0", "") + sign[i][1];
 }
 
 function setEventListeners(evt) {


### PR DESCRIPTION
Change function `numberFormat` to match the formatting on YouTube more closely. 
In the range of millions, YouTube hides decimals, which `numberFormat` does not do yet.
Related issue: #201