### PR TITLE
Fix Issue #195: Fix bug where extension was being loaded on youtube music domains

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -8,6 +8,8 @@
 // @icon         https://github.com/Anarios/return-youtube-dislike/raw/main/Icons/Return%20Youtube%20Dislike%20-%20Transparent.png
 // @author       Anarios & JRWR
 // @match        *://*.youtube.com/*
+// @exclude      *://music.youtube.com/*
+// @exclude      *://*.music.youtube.com/*
 // @compatible   chrome
 // @compatible   firefox
 // @compatible   opera

--- a/Extensions/chrome/manifest.json
+++ b/Extensions/chrome/manifest.json
@@ -21,6 +21,7 @@
   "content_scripts": [
     {
       "matches": ["*://*.youtube.com/*"],
+      "exclude_matches": ["*://*.music.youtube.com/*"],
       "js": ["return-youtube-dislike.content-script.js"],
       "run_at": "document_start",
       "css": ["content-style.css"]

--- a/Extensions/firefox/manifest.json
+++ b/Extensions/firefox/manifest.json
@@ -17,6 +17,7 @@
   "content_scripts": [
     {
       "matches": ["*://*.youtube.com/*"],
+      "exclude_matches": ["*://*.music.youtube.com/*"],
       "js": ["content-script.js"],
       "run_at": "document_idle",
       "css": ["content-style.css"]


### PR DESCRIPTION
It seems to me that the extension should not be run on youtube music domains. 

Although the error was only happening on chrome, I also added the exclusion to Firefox for consistently.