### PR TITLE
Stop calculating dislike when creator has disabled

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -165,6 +165,12 @@ function setState() {
   fetch(`https://www.youtube.com/watch?v=${getVideoId()}`).then((response) => {
     response.text().then((text) => {
       let result = getDislikesFromYoutubeResponse(text);
+      if (result === false){
+        cLog("response from youtube:");
+        cLog("Creator has opted to hide likes and dislikes");
+        statsSet = true;
+        return;
+      }
       if (result) {
         cLog("response from youtube:");
         cLog(JSON.stringify(result));
@@ -181,7 +187,8 @@ function setState() {
   fetch(
     `https://returnyoutubedislikeapi.com/votes?videoId=${getVideoId()}`
   ).then((response) => {
-    response.json().then((json) => {
+    response.json().then(async (json) => {
+      await sleep(1000);
       if (json && !statsSet) {
         const { dislikes, likes } = json;
         cLog(`Received count: ${dislikes}`);
@@ -190,6 +197,10 @@ function setState() {
       }
     });
   });
+}
+
+function sleep(ms) {
+  new Promise(resolve => setTimeout(resolve, ms));
 }
 
 function likeClicked() {
@@ -255,6 +266,7 @@ function getDislikesFromYoutubeResponse(htmlResponse) {
   let jsonStr = htmlResponse.substring(start, end);
   let jsonResult = JSON.parse(jsonStr);
   let rating = jsonResult.averageRating;
+  if (jsonResult.allowRatings === false) return false;
 
   start = htmlResponse.indexOf('"topLevelButtons":[', end);
   start =

--- a/Extensions/chrome/return-youtube-dislike.background.js
+++ b/Extensions/chrome/return-youtube-dislike.background.js
@@ -86,6 +86,7 @@ function getDislikesFromYoutubeResponse(htmlResponse) {
   let jsonStr = htmlResponse.substring(start, end);
   let jsonResult = JSON.parse(jsonStr);
   let rating = jsonResult.averageRating;
+  if (jsonResult.allowRatings === false) return false;
 
   start = htmlResponse.indexOf('"topLevelButtons":[', end);
   start =

--- a/Extensions/chrome/return-youtube-dislike.script.js
+++ b/Extensions/chrome/return-youtube-dislike.script.js
@@ -81,6 +81,12 @@
         videoId: getVideoId(window.location.href),
       },
       function (response) {
+        if (response === false){
+          cLog("response from youtube:");
+          cLog("Creator has opted to hide likes and dislikes");
+          statsSet = true;
+          return;
+        }
         if (response != undefined) {
           cLog("response from youtube:");
           cLog(JSON.stringify(response));
@@ -106,9 +112,10 @@
         videoId: getVideoId(window.location.href),
         state: getState().current,
       },
-      function (response) {
+      async function (response) {
         cLog("response from api:");
         cLog(JSON.stringify(response));
+        await sleep(1000);
         if (response != undefined && !statsSet) {
           const formattedDislike = numberFormat(response.dislikes);
           // setLikes(response.likes);
@@ -118,6 +125,10 @@
         }
       }
     );
+  }
+
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   function likeClicked() {

--- a/Extensions/firefox/return-youtube-dislike.background.js
+++ b/Extensions/firefox/return-youtube-dislike.background.js
@@ -96,6 +96,7 @@ function getDislikesFromYoutubeResponse(htmlResponse) {
   let jsonStr = htmlResponse.substring(start, end);
   let jsonResult = JSON.parse(jsonStr);
   let rating = jsonResult.averageRating;
+  if (jsonResult.allowRatings === false) return false;
 
   start = htmlResponse.indexOf('"topLevelButtons":[', end);
   start =

--- a/Extensions/firefox/return-youtube-dislike.script.js
+++ b/Extensions/firefox/return-youtube-dislike.script.js
@@ -76,6 +76,12 @@ function setState() {
       videoId: getVideoId(window.location.href),
     },
     function (response) {
+      if (response === false){
+        cLog("response from youtube:");
+        cLog("Creator has opted to hide likes and dislikes");
+        statsSet = true;
+        return;
+      }
       if (response != undefined) {
         cLog("response from youtube:");
         cLog(JSON.stringify(response));
@@ -100,9 +106,10 @@ function setState() {
       videoId: getVideoId(window.location.href),
       state: getState().current,
     },
-    function (response) {
+    async function (response) {
       cLog("response from api:");
       cLog(JSON.stringify(response));
+      await sleep(1000);
       if (response != undefined && !statsSet) {
         const formattedDislike = numberFormat(response.dislikes);
         storedData.dislikes = response.dislikes;
@@ -114,6 +121,9 @@ function setState() {
       }
     }
   );
+}
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 function likeClicked() {}


### PR DESCRIPTION
This fix will stop updating the dislike count by checking the **_allowRatings_** property


P.S: I am not clear why we get the exact same details like counts from https://returnyoutubedislikeapi.com/votes?videoId, so I have added a delay in order to avoid race conditions when buttons are being manipulated
