### PR TITLE
Fix dislike count increasing in Firefox.

### DIFF
--- a/Extensions/firefox/return-youtube-dislike.script.js
+++ b/Extensions/firefox/return-youtube-dislike.script.js
@@ -116,7 +116,13 @@ function setState() {
   );
 }
 
-function likeClicked() {}
+function likeClicked() {
+  if (storedData.previousState === 'disliked') {
+    storedData.dislikes--;
+    setDislikes(numberFormat(storedData.dislikes));
+    storedData.previousState = 'liked';
+  }
+}
 
 function dislikeClicked() {
   let state = getState().current;


### PR DESCRIPTION
likeClicked() suppose to decrease the dislike count by 1 if the previous state is "disliked", but the function is empty on Firefox.