### PR TITLE
Extract language from `html` instead of browser UI

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -289,7 +289,7 @@ function roundDown(num) {
 }
 
 function numberFormat(numberState) {
-  const userLocales = navigator.language;
+  const userLocales = document.documentElement.lang;
 
   const formatter = Intl.NumberFormat(userLocales, {
     notation: "compact",


### PR DESCRIPTION
If a user uses a different language in YouTube and browser settings, then a reduced number of dislikes will be displayed on the YouTube video page in the same language as YouTube itself.