### PR TITLE
Fix issue 180: Clips not working

### DIFF
--- a/Extensions/chrome/return-youtube-dislike.script.js
+++ b/Extensions/chrome/return-youtube-dislike.script.js
@@ -154,8 +154,12 @@
 
   function getVideoId(url) {
     const urlObject = new URL(url);
-    const videoId = urlObject.searchParams.get("v");
-    return videoId;
+    const pathname = urlObject.pathname;
+    if (pathname.startsWith('/clips')) {
+      return document.querySelector("meta[itemprop='videoId']").content;
+    } else {
+      return urlObject.searchParams.get("v");
+    }
   }
 
   function isVideoLoaded() {

--- a/Extensions/firefox/return-youtube-dislike.script.js
+++ b/Extensions/firefox/return-youtube-dislike.script.js
@@ -140,8 +140,12 @@ function setInitalState() {
 
 function getVideoId(url) {
   const urlObject = new URL(url);
-  const videoId = urlObject.searchParams.get("v");
-  return videoId;
+  const pathname = urlObject.pathname;
+  if (pathname.startsWith('/clips')) {
+    return document.querySelector("meta[itemprop='videoId']").content;
+  } else {
+    return urlObject.searchParams.get("v");
+  }
 }
 
 function isVideoLoaded() {


### PR DESCRIPTION
Closes #180 
A clip's stats come directly from source video. This adds the ability to extract that original ID.