### PR TITLE
Fix Dislikes of Private Videos are "NaN"

### DIFF
--- a/Extensions/chrome/return-youtube-dislike.script.js
+++ b/Extensions/chrome/return-youtube-dislike.script.js
@@ -24,7 +24,7 @@ const NEUTRAL_STATE = "NEUTRAL_STATE";
       return document.querySelector(
         "ytd-menu-renderer.ytd-watch-metadata > div"
       );
-    //---   If Menu Element Isnt Displayed:   ---//
+      //---   If Menu Element Isnt Displayed:   ---//
     } else {
       return document
         .getElementById("menu-container")
@@ -58,12 +58,12 @@ const NEUTRAL_STATE = "NEUTRAL_STATE";
 
   function getState() {
     if (isVideoLiked()) {
-      return {current: LIKED_STATE, previous: storedData.previousState};
+      return { current: LIKED_STATE, previous: storedData.previousState };
     }
     if (isVideoDisliked()) {
-      return {current: DISLIKED_STATE, previous: storedData.previousState};
+      return { current: DISLIKED_STATE, previous: storedData.previousState };
     }
-    return {current: NEUTRAL_STATE, previous: storedData.previousState};
+    return { current: NEUTRAL_STATE, previous: storedData.previousState };
   }
 
   //---   Sets The Likes And Dislikes Values   ---//
@@ -89,7 +89,7 @@ const NEUTRAL_STATE = "NEUTRAL_STATE";
           cLog("response from youtube:");
           cLog(JSON.stringify(response));
           try {
-            if (response.likes && response.dislikes) {
+            if ("likes" in response && "dislikes" in response) {
               const formattedDislike = numberFormat(response.dislikes);
               setDislikes(formattedDislike);
               storedData.dislikes = parseInt(response.dislikes);
@@ -113,7 +113,7 @@ const NEUTRAL_STATE = "NEUTRAL_STATE";
       function (response) {
         cLog("response from api:");
         cLog(JSON.stringify(response));
-        if (response != undefined && !statsSet) {
+        if (response != undefined && !("traceId" in response) && !statsSet) {
           const formattedDislike = numberFormat(response.dislikes);
           // setLikes(response.likes);
           setDislikes(formattedDislike);
@@ -136,7 +136,7 @@ const NEUTRAL_STATE = "NEUTRAL_STATE";
   function dislikeClicked() {
     let state = getState().current;
 
-    console.log("Dislike State:",getState());
+    console.log("Dislike State:", getState());
 
     if (state == DISLIKED_STATE) {
       storedData.dislikes++;

--- a/Extensions/firefox/return-youtube-dislike.script.js
+++ b/Extensions/firefox/return-youtube-dislike.script.js
@@ -56,12 +56,12 @@ function isVideoNotDisliked() {
 
 function getState() {
   if (isVideoLiked()) {
-    return {current: LIKED_STATE, previous: storedData.previousState};
+    return { current: LIKED_STATE, previous: storedData.previousState };
   }
   if (isVideoDisliked()) {
-    return {current: DISLIKED_STATE, previous: storedData.previousState};
+    return { current: DISLIKED_STATE, previous: storedData.previousState };
   }
-  return {current: NEUTRAL_STATE, previous: storedData.previousState};
+  return { current: NEUTRAL_STATE, previous: storedData.previousState };
 }
 
 //---   Sets The Likes And Dislikes Values   ---//
@@ -84,7 +84,7 @@ function setState() {
         cLog("response from youtube:");
         cLog(JSON.stringify(response));
         try {
-          if (response.likes && response.dislikes) {
+          if ("likes" in response && "dislikes" in response) {
             const formattedDislike = numberFormat(response.dislikes);
             setDislikes(formattedDislike);
             storedData.dislikes = parseInt(response.dislikes);
@@ -107,7 +107,7 @@ function setState() {
     function (response) {
       cLog("response from api:");
       cLog(JSON.stringify(response));
-      if (response != undefined && !statsSet) {
+      if (response != undefined && !("traceId" in response) && !statsSet) {
         const formattedDislike = numberFormat(response.dislikes);
         storedData.dislikes = response.dislikes;
         // setLikes(response.likes);


### PR DESCRIPTION
Will fix #230

List of changes:

* Adding a check to see if traceId exists on response.
  This appears during error, so it will prevent setting dislike count to NaN.

* Changed a way to check if fields exist.
  Because the old way, 0 likes or 0 dislikes are considered invalid.

Also, small changes made by my auto formatter.