### PR TITLE
Fix: "has been blocked by CORS policy" for redirection from "youtube.…

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -199,7 +199,7 @@ function setState() {
   if (isMobile) {
     GM.xmlHttpRequest({
       method: "GET",
-      url: `https://youtube.com/watch?v=${getVideoId()}`,
+      url: `https://www.youtube.com/watch?v=${getVideoId()}`,
       headers: {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.3674"
       },
@@ -219,7 +219,7 @@ function setState() {
     });
   }
   else {
-    fetch(`https://youtube.com/watch?v=${getVideoId()}`).then((response) => {
+    fetch(`https://www.youtube.com/watch?v=${getVideoId()}`).then((response) => {
       response.text().then((text) => {
         let result = getDislikesFromYoutubeResponse(text);
         if (result) {


### PR DESCRIPTION
Use "www.youtube.com" instread of "youtube.com" in UserScript to avoid cors error:

```
Access to fetch at 'https://www.youtube.com/watch?v=...' (redirected from 'https://youtube.com/watch?v=...') from origin 'https://www.youtube.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```