### PR TITLE
[fix] YouTube Mobile Locale URL Doesn't Exist

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -354,11 +354,11 @@ function roundDown(num) {
 }
 
 function numberFormat(numberState) {
-  const userLocales = new URL(
-    Array.from(document.querySelectorAll("head > link[rel='search']"))
-      ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
-      ?.getAttribute("href")
-  )?.searchParams?.get("locale");
+  let localeURL = Array.from(document.querySelectorAll("head > link[rel='search']"))
+    ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
+    ?.getAttribute("href");
+  
+  const userLocales = localeURL ? new URL(localeURL)?.searchParams?.get("locale") : 'en';
 
   const formatter = Intl.NumberFormat(
     document.documentElement.lang || userLocales,

--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -358,10 +358,10 @@ function numberFormat(numberState) {
     ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
     ?.getAttribute("href");
   
-  const userLocales = localeURL ? new URL(localeURL)?.searchParams?.get("locale") : 'en';
+  const userLocales = localeURL ? new URL(localeURL)?.searchParams?.get("locale") : null;
 
   const formatter = Intl.NumberFormat(
-    document.documentElement.lang || userLocales,
+    document.documentElement.lang || userLocales || navigator.language,
     {
       notation: "compact",
       minimumFractionDigits: 1,

--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -358,7 +358,7 @@ function numberFormat(numberState) {
     ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
     ?.getAttribute("href");
   
-  const userLocales = localeURL ? new URL(localeURL)?.searchParams?.get("locale") : null;
+  const userLocales = localeURL ? new URL(localeURL)?.searchParams?.get("locale") : document.body.lang;
 
   const formatter = Intl.NumberFormat(
     document.documentElement.lang || userLocales || navigator.language,


### PR DESCRIPTION
On m.youtube.com, the locale URL doesn't exist. This will throw an invalid URL (passes undefined to the URL constructor).

On quick glance it doesn't appear that there's a good alternative on mobile, so I just fallback to 'en'.