### PR TITLE
Add draft functionality for creators to share dislikes [DRAFT]

### DIFF
--- a/Extensions/chrome/creator-publish.content-script.js
+++ b/Extensions/chrome/creator-publish.content-script.js
@@ -1,0 +1,11 @@
+chrome.runtime.sendMessage({}, (securityToken) => {
+    var script = document.createElement("script");
+    script.setAttribute("security-token", securityToken);
+    script.setAttribute("extension-id", chrome.runtime.id);
+    script.src = chrome.runtime.getURL("creator-publish.script.js");
+    script.onload = function () {
+      this.remove();
+    };
+    (document.head || document.documentElement).appendChild(script);
+  });
+  

--- a/Extensions/chrome/creator-publish.content-stye.css
+++ b/Extensions/chrome/creator-publish.content-stye.css
@@ -1,0 +1,15 @@
+.returnyoutube-button{
+    background-color:#1c1c1c;
+    padding:10px;
+    border-radius: 2px;
+    border: 1px #333 solid;
+    padding-left:30px;
+    background-image: url("https://github.com/Anarios/return-youtube-dislike/blob/main/Icons/Return%20Youtube%20Dislike%20-%20Dark.jpg?raw=true");
+    background-repeat: no-repeat;
+    background-size:30px auto;
+    background-position: 2px center;
+    font-size:1.2em;
+}
+.returnyoutube-button:hover{
+    cursor: pointer;
+}

--- a/Extensions/chrome/creator-publish.script.js
+++ b/Extensions/chrome/creator-publish.script.js
@@ -1,0 +1,89 @@
+function cLog(message, writer) {
+    message = `[return youtube dislike]: ${message}`;
+    if (writer) {
+        writer(message);
+    } else {
+        console.log(message);
+    }
+}
+
+// API credientials are fetched when making a request
+let authorizationHeader;
+let innertubeApiKey;
+
+function overrideXHR(defaultOpen, defaultSetHeader) {
+
+    // Override open() method to obtain innerTube key
+    XMLHttpRequest.prototype.open = function (method, url) {
+        if (!innertubeApiKey && url.includes("&key")) {
+            innertubeApiKey = new URLSearchParams(new URL(url, window.location).search).get("key");
+            cLog("Obtained innerTube api key: " + innertubeApiKey);
+        }
+        this.url = url;
+        return defaultOpen.apply(this, arguments);
+    }
+    // Override setRequestHeader to obtain Authorization header
+    XMLHttpRequest.prototype.setRequestHeader = function (header, value) {
+        if (!authorizationHeader && header.toLowerCase() == "authorization" && this.url.includes("youtubei")) {
+            authorizationHeader = value;
+            cLog("Obtained authorization header: " + value);
+        }
+        return defaultSetHeader.apply(this, arguments);
+    }
+}
+function isLoaded() {
+    return document.querySelector("div.right-section.style-scope.ytcp-header") !== null;
+}
+let interval = setInterval(() => {
+    if (isLoaded()) {
+        addButton();
+        clearInterval(interval);
+    }
+}, 16);
+function addButton() {
+    // In case the clearInterval breaks..
+    if (document.querySelector(".returnyoutube-button")) {
+        return
+    }
+    let button = document.createElement("div");
+    button.classList.add("returnyoutube-button");
+    button.innerText = "Share Dislike Count";
+    let buttonContainer = document.querySelector("div.right-section.style-scope.ytcp-header");
+    buttonContainer.insertBefore(button, document.querySelector("ytcp-button#create-icon.style-scope.ytcp-header"));
+    button.addEventListener("click", fetchDislikes);
+}
+async function fetchDislikes() {
+    if (!authorizationHeader) {
+        alert("Authorization header could not be fetched.. try hard-reloading the page or open a github issue");
+        return;
+    }
+    if (!innertubeApiKey) {
+        alert("Innertube API key could not be fetched.. try hard-reloading the page or open a github issue");
+        return;
+    }
+    let data = await (await fetch(`https://studio.youtube.com/youtubei/v1/creator/search_creator_entities?alt=json&key=${innertubeApiKey}`, {
+        "headers": {
+            "authorization": authorizationHeader,
+            "content-type": "application/json"
+        },
+        "body": JSON.stringify({
+            numVideos: 100000,
+            query: '',
+            videoMask: { videoId: true, metrics: { all: true } },
+            context: { client: { clientName: 62, clientVersion: '1.20211206.02.00' } }
+        }),
+        "method": "POST"
+    })).json();
+    let videoDislikes = data.videos.map(video => {
+        return {
+            id: video.video.videoId,
+            dislikes: video.video.metrics.dislikeCount
+        }
+    });
+    let sure = confirm(`Successfully fetched dislikes of ${videoDislikes.length} videos. Do you want to publish them?`);
+    if(!sure){
+        return;
+    }
+    alert("Please add a youtube creator dislike endpoint before merging. Dislikes fetched: " + JSON.stringify(videoDislikes));
+}
+overrideXHR(XMLHttpRequest.prototype.open, XMLHttpRequest.prototype.setRequestHeader)

--- a/Extensions/chrome/manifest.json
+++ b/Extensions/chrome/manifest.json
@@ -21,10 +21,16 @@
   "content_scripts": [
     {
       "matches": ["*://*.youtube.com/*"],
-      "exclude_matches": ["*://*.music.youtube.com/*"],
+      "exclude_matches": ["*://*.music.youtube.com/*", "*://*.studio.youtube.com/*"],
       "js": ["return-youtube-dislike.content-script.js"],
       "run_at": "document_start",
       "css": ["content-style.css"]
+    },
+    {
+      "matches": ["*://studio.youtube.com/*"],
+      "js": ["creator-publish.content-script.js"],
+      "run_at": "document_start",
+      "css": ["creator-publish.content-stye.css"]
     }
   ],
   "externally_connectable": {
@@ -32,7 +38,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["return-youtube-dislike.script.js"],
+      "resources": ["return-youtube-dislike.script.js", "creator-publish.script.js"],
       "matches": ["*://*.youtube.com/*"]
     }
   ]


### PR DESCRIPTION
Since the dislike api is now gone, I thought it was a good moment to work on this. When going on the studio page, you get a new button to share your dislikes. It works so far, however there are still several issues, which is why it is currently a draft:

- I recommend adding a new API endpoint instead of reusing the old one. Currently the counts are shown in the browser for debugging purposes, but not sent anywhere.
- I have no experience with Firefox addons. The current commit is only for the chrome extension, I hope somebody else can port it
- It needs to be tested with more videos. It seems to be working fine on my channel with 31 videos and my other channel with 3 videos, but I haven't tested it with hundreds or thousands of videos

Some screenshots:

![screen_Mo 13 Dez 2021 22:17:25 CET](https://user-images.githubusercontent.com/69308275/145890704-32fb62cf-16c6-4b4c-bffe-86a499b861e2.png)
![screen_Mo 13 Dez 2021 22:17:14 CET](https://user-images.githubusercontent.com/69308275/145890752-6eab7f24-c460-4745-9149-92aef9c14c0e.png)
