### PR TITLE
remove unused functions from extension code

### DIFF
--- a/Extensions/combined/ryd.background.js
+++ b/Extensions/combined/ryd.background.js
@@ -131,37 +131,6 @@ api.storage.sync.get(null, (res) => {
 const sentIds = new Set();
 let toSend = [];
 
-function getDislikesFromYoutubeResponse(htmlResponse) {
-  let start =
-    htmlResponse.indexOf('"videoDetails":') + '"videoDetails":'.length;
-  let end =
-    htmlResponse.indexOf('"isLiveContent":false}', start) +
-    '"isLiveContent":false}'.length;
-  if (end < start) {
-    end =
-      htmlResponse.indexOf('"isLiveContent":true}', start) +
-      '"isLiveContent":true}'.length;
-  }
-  let jsonStr = htmlResponse.substring(start, end);
-  let jsonResult = JSON.parse(jsonStr);
-  let rating = jsonResult.averageRating;
-
-  start = htmlResponse.indexOf('"topLevelButtons":[', end);
-  start =
-    htmlResponse.indexOf('"accessibilityData":', start) +
-    '"accessibilityData":'.length;
-  end = htmlResponse.indexOf("}", start);
-  let likes = +htmlResponse.substring(start, end).replace(/\D/g, "");
-  let dislikes = (likes * (5 - rating)) / (rating - 1);
-  let result = {
-    likes,
-    dislikes: Math.abs(Math.round(dislikes)),
-    rating,
-    viewCount: +jsonResult.viewCount,
-  };
-  return result;
-}
-
 function sendUserSubmittedStatisticsToApi(statistics) {
   fetch(`${apiUrl}/votes/user-submitted`, {
     method: "POST",

--- a/Extensions/combined/ryd.content-script.js
+++ b/Extensions/combined/ryd.content-script.js
@@ -67,14 +67,6 @@ function RYD() {
     return getDislikeButton().classList.contains("style-default-active");
   }
 
-  function isVideoNotLiked() {
-    return getLikeButton().classList.contains("style-text");
-  }
-
-  function isVideoNotDisliked() {
-    return getDislikeButton().classList.contains("style-text");
-  }
-
   function checkForSignInButton() {
     if (
       document.querySelector(


### PR DESCRIPTION
There was 1 unused function in background script `getDislikesFromYoutubeResponse()`, which was being used before 13th as a fallback to show dislikes to users.
It is not being used anywhere in the code anymore.

In the content-script there were 2 methods `isVideoNotLiked()` & `isVideoNotDisliked()` which were also not being used anymore.
content-script already have `isVideoLiked()` & `isVideoDisliked()` method which are being used now.