### PR TITLE
Update  build scripts, .gitignore and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ yarn-error.log*
 *.sw*
 
 node_modules
+
+# Build files
+Extensions/combined/bundled-content-script.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,12 @@ npm install
 2. Run the following command to create `bundled-content-script.js` which is used in `manifest.json`
 
 ```
-npm run bundle
-```
+npm start // to create the build file(s) and start a file watcher that hot-reloads on save
 
-This will also start a watcher that re-bundles automatically once you save a file inside the source.
+// or
+
+npm run build // to create the build file(s) once
+```
 
 Congratulations, You are now ready to develop!
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Chrome extension to return youtube dislikes",
   "main": "ryd.content-script.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "bundle": "node_modules/.bin/webpack \"./Extensions/combined/ryd.content-script.js\" -o \"./Extensions/combined\""
+    "start": "node_modules/.bin/webpack \"./Extensions/combined/ryd.content-script.js\" -o \"./Extensions/combined\" --watch",
+    "build": "node_modules/.bin/webpack \"./Extensions/combined/ryd.content-script.js\" -o \"./Extensions/combined\"",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,5 +10,4 @@ module.exports = {
     ramda: "R",
   },
   module: {},
-  watch: true
 };


### PR DESCRIPTION
## What
- Rename `npm run bundle` to `npm run build` and remove file watcher from config
- Add `npm start` script with file watcher in options
- Update docs with new/renamed scripts
- Add build file to .gitignore

## Why
- Prevent build files from accidentally being committed
- Make build and start scripts follow more common naming conventions to make it easier for new contributors
