### PR TITLE
Add version number to extension's menu

### DIFF
--- a/Extensions/combined/popup.html
+++ b/Extensions/combined/popup.html
@@ -13,6 +13,7 @@
       <svg width="48" viewBox="0 0 24 24"><path d="M14.9 3H6c-.9 0-1.6.5-1.9 1.2l-3 7c-.1.3-.1.5-.1.7v2c0 1.1.9 2 2 2h6.3l-.9 4.5c-.1.5 0 1 .4 1.4l1.1 1.1 6.5-6.6c.4-.4.6-.9.6-1.4V5c-.1-1.1-1-2-2.1-2zm7.4 12.8h-2.9c-.4 0-.7-.3-.7-.7V3.9c0-.4.3-.7.7-.7h2.9c.4 0 .7.3.7.7V15c0 .4-.3.8-.7.8z" fill="red"/><path d="m8 12.5 5.1-2.9L8 6.7v5.8z" fill="#fff"/></svg>
       <h1>Return YouTube Dislike</h1>
       <p>by Dmitrii Selivanov & Community</p>
+      <p>v2.0.0.3</p>
 
       <button id="link_website">Website</button>
       <button id="link_github">GitHub</button>

--- a/Extensions/combined/popup.html
+++ b/Extensions/combined/popup.html
@@ -13,7 +13,7 @@
       <svg width="48" viewBox="0 0 24 24"><path d="M14.9 3H6c-.9 0-1.6.5-1.9 1.2l-3 7c-.1.3-.1.5-.1.7v2c0 1.1.9 2 2 2h6.3l-.9 4.5c-.1.5 0 1 .4 1.4l1.1 1.1 6.5-6.6c.4-.4.6-.9.6-1.4V5c-.1-1.1-1-2-2.1-2zm7.4 12.8h-2.9c-.4 0-.7-.3-.7-.7V3.9c0-.4.3-.7.7-.7h2.9c.4 0 .7.3.7.7V15c0 .4-.3.8-.7.8z" fill="red"/><path d="m8 12.5 5.1-2.9L8 6.7v5.8z" fill="#fff"/></svg>
       <h1>Return YouTube Dislike</h1>
       <p>by Dmitrii Selivanov & Community</p>
-      <p>v2.0.0.3</p>
+      <p id="ext-version"></p>
 
       <button id="link_website">Website</button>
       <button id="link_github">GitHub</button>

--- a/Extensions/combined/popup.js
+++ b/Extensions/combined/popup.js
@@ -4,7 +4,17 @@ const config = {
   showAdvancedMessage: "Show Settings",
   hideAdvancedMessage: "Hide Settings",
   disableVoteSubmission: false,
+}
 
+ function initConfig() {
+  initializeVersionNumber();
+  }
+
+ function initializeVersionNumber() {
+  const version = chrome.runtime.getManifest().version;
+  document.getElementById('ext-version').innerHTML = 'v' + version;
+}
+  
   links: {
     website: "https://returnyoutubedislike.com",
     github: "https://github.com/Anarios/return-youtube-dislike",

--- a/Extensions/combined/popup.js
+++ b/Extensions/combined/popup.js
@@ -10,6 +10,7 @@ const config = {
     github: "https://github.com/Anarios/return-youtube-dislike",
     discord: "https://discord.gg/mYnESY4Md5",
     donate: 'https://returnyoutubedislike.com/donate'
+    wip
   },
 };
 

--- a/Extensions/combined/popup.js
+++ b/Extensions/combined/popup.js
@@ -9,8 +9,8 @@ const config = {
     website: "https://returnyoutubedislike.com",
     github: "https://github.com/Anarios/return-youtube-dislike",
     discord: "https://discord.gg/mYnESY4Md5",
-    donate: 'https://returnyoutubedislike.com/donate'
-    wip
+    donate: 'https://returnyoutubedislike.com/donate',
+    faq: 'https://returnyoutubedislike.com/faq'
   },
 };
 
@@ -27,9 +27,14 @@ document.getElementById("link_discord").addEventListener("click", () => {
   chrome.tabs.create({ url: config.links.discord });
 });
 
+document.getElementById("link_faq").addEventListener("click", () => {
+  chrome.tabs.create({ url: config.links.faq });
+});
+
 document.getElementById("link_donate").addEventListener("click", () => {
   chrome.tabs.create({ url: config.links.donate });
 });
+
 
 document.getElementById("disable_vote_submission").addEventListener("click", (ev) => {
   chrome.storage.sync.set({ disableVoteSubmission: ev.target.checked });
@@ -80,6 +85,7 @@ document.querySelector('#login')
 .addEventListener('click', function () {
   chrome.runtime.sendMessage({ message: 'get_auth_token' });
 });
+
 
 document.querySelector("#log_off").addEventListener("click", function () {
   chrome.runtime.sendMessage({ message: "log_off" });


### PR DESCRIPTION
Dinamically takes the manifest's version number and displays it under the credits text. **Full compatibility with Firefox and Safari is the current priority.** Placement of the number must be changed to be in the bottom right corner. Currently broken i guess.