### PR TITLE
add API documentation with get vote example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,37 @@ and estimates based on view\like ratios.
 
 You can learn more at our website at: [returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
 
+## API documentation
+
+Third party use of this open API is allowed with the following restrictions:
+
+- **Attribution**: This project should be clearly attributed with either a link to this repo or a link to [returnyoutubedislike.com](https://returnyoutubedislike.com/).
+- **Rate Limiting**: There are per client rate limits in place of 100 per minute and 10'000 per day. This will return a *429* status code indicating that your application should back off.
+
+The API is accessible over the following base URL:  
+https://returnyoutubedislikeapi.com  
+
+List of available endpoints is available here:  
+https://returnyoutubedislikeapi.com/swagger/index.html
+
+### Get votes
+Example to get votes of a given YouTube video ID:  
+`/votes?videoId=kxOuG8jMIgI`
+
+```json
+{
+    "id": "kxOuG8jMIgI",
+    "dateCreated": "2021-12-20T12:25:54.418014Z",
+    "likes": 27326,
+    "dislikes": 498153,
+    "rating": 1.212014408444885,
+    "viewCount": 3149885,
+    "deleted": false
+}
+```
+
+None existing YouTube ID will return status code *404* "Not Found".  
+Wrong formed YouTube ID will return *400* "Bad Request".
 
 ## Contributing
 


### PR DESCRIPTION
This is a follow up for #328, basic API documentation starting with some general info and an example to `get` votes. 

To `post` votes, I think I understand what you are trying to do with your puzzle solver, but I doubt that this is feasible to integrate into third party applications like that. Maybe in the future it could be worth it to think about an JWT authentication system or similar so people could make properly authenticated requests.

I'm assuming you have your cloudflare rate limiter set to send standard status code `429`? I didn't want to DOS you just to find out. :-) 