### PR TITLE
add link to redirect to security faq on website

### DIFF
--- a/Website/pages/faq.vue
+++ b/Website/pages/faq.vue
@@ -58,7 +58,7 @@ export default {
         question:
           "What data do you collect and how is it treated?",
         answer:
-          "to be added + link",
+          "The extension only collects data that is strictly necessary for it to function properly, such as IP address or ID of the video you're watching. None of your data will ever be sold to 3rd parties. If you would like to know more about how we handle security and privacy check out our [add link here to security-faq.md]",
       },
     ],
   }),

--- a/Website/pages/faq.vue
+++ b/Website/pages/faq.vue
@@ -54,6 +54,12 @@ export default {
         answer:
           "The backend will switch to using a combination of archived dislike stats, estimates extrapolated from extension user data, and estimates based on view/like ratios for videos whose dislikes weren't archived as well as outdated dislike count archives.",
       },
+      {
+        question:
+          "What data do you collect and how is it treated?",
+        answer:
+          "to be added + link",
+      },
     ],
   }),
 };


### PR DESCRIPTION
Makes the security faq more accessible to people that don't really know much about github. Wording needs to be yet decided