### PR TITLE
Format numbers the same way as the extension for the UserScript

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -311,22 +311,22 @@ function roundDown(num) {
 }
 
 function numberFormat(numberState) {
-  let localeURL = Array.from(document.querySelectorAll("head > link[rel='search']"))
-    ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
-    ?.getAttribute("href");
-
-  const userLocales = localeURL ? new URL(localeURL)?.searchParams?.get("locale") : document.body.lang;
-
+  let userLocales;
+  try {
+    userLocales = new URL(
+      Array.from(document.querySelectorAll("head > link[rel='search']"))
+        ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
+        ?.getAttribute("href")
+    )?.searchParams?.get("locale");
+  } catch {}
   const formatter = Intl.NumberFormat(
     document.documentElement.lang || userLocales || navigator.language,
     {
       notation: "compact",
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 1,
     }
   );
 
-  return formatter.format(roundDown(numberState)).replace(/\.0|,0/, "");
+  return formatter.format(roundDown(numberState));
 }
 
 function setEventListeners(evt) {


### PR DESCRIPTION
Related issue #201
Related comment https://github.com/Anarios/return-youtube-dislike/issues/201#issuecomment-1000491557 
Continuing pull request #202 

This pull request fixes the issue with formatting numbers when using the user script by using the same number-formatter as the extension: https://github.com/Anarios/return-youtube-dislike/blob/main/Extensions/combined/src/utils.js#L9