### PR TITLE
Updated link for iOS (Jailbreak) installation

### DIFF
--- a/Website/pages/install.vue
+++ b/Website/pages/install.vue
@@ -92,7 +92,7 @@ export default {
       scriptLink:
         "https://github.com/Anarios/return-youtube-dislike/raw/main/Extensions/UserScript/Return%20Youtube%20Dislike.user.js",
 
-      iosJailbreakLink: "https://repo.lillieweeb001.xyz/",
+      iosJailbreakLink: "https://chariz.com/get/return-youtube-dislike/",
     };
   },
 };


### PR DESCRIPTION
RYD for iOS has been moved to Chariz repository. Updates for this add-on going forward will be here.