### PR TITLE
change text from "DISLIKES DISABLED" to "DISLIKE"

### DIFF
--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -9,7 +9,7 @@ const LIKED_STATE = "LIKED_STATE";
 const DISLIKED_STATE = "DISLIKED_STATE";
 const NEUTRAL_STATE = "NEUTRAL_STATE";
 
-const DISLIKES_DISABLED_TEXT = "DISLIKES DISABLED";
+const DISLIKES_DISABLED_TEXT = "DISLIKE";
 
 let extConfig = {
   disableVoteSubmission: false,


### PR DESCRIPTION
The text doesn't fit the UI currently if the likes/dislikes are disabled.
![The current UI state with this extension. Note how the DISLIKES DISABLED looks out of place.](https://user-images.githubusercontent.com/87399016/150528470-b9e20ff9-de7f-4847-b4d7-daef869cf584.png)

This fork would feel more at home here.
![The state of this fork. The UI looks normal now.](https://user-images.githubusercontent.com/87399016/150528548-248f1115-318c-47c9-a7b1-4e78a922dbf2.png)
