### PR TITLE
Add option to get dislikes manually from website

### DIFF
--- a/Website/pages/index.vue
+++ b/Website/pages/index.vue
@@ -54,6 +54,11 @@
       </v-btn>
     </div>
 
+    <div class="mb-4" style="color: #999">
+      Get dislikes manually: <input placeholder=" Video URL">
+      <p id="output"></p>
+    </div>
+
     <v-spacer />
 
     <div id="sponsors" class="d-flex flex-column items-center py-8">
@@ -111,6 +116,18 @@ export default {
       ],
     };
   },
+  mounted() {
+    const YOUTUBE_REGEX = /(?:http:|https:)*?\/\/(?:www\.|)(?:youtube\.com|m\.youtube\.com|youtu\.|youtube-nocookie\.com).*(?:v=|v%3D|v\/|(?:a|p)\/(?:a|u)\/\d.*\/|watch\?|vi(?:=|\/)|\/embed\/|oembed\?|be\/|e\/)([^&?%#\/\n]*)/;
+    let lastVideoId = "";
+    window.oninput = (e) => {
+      const videoId = (e.target.value.match(YOUTUBE_REGEX) || {})[1] || e.target.value;
+      if (videoId !== lastVideoId && videoId.length === 11) {
+        fetch("https://returnyoutubedislikeapi.com/votes?videoId=" + (lastVideoId = videoId))
+          .then(resp => resp.json())
+          .then(data => document.getElementById("output").innerText = "Likes=" + data.likes + " Dislikes=" + data.dislikes);
+      }
+    };
+  },
 };
 </script>
 
@@ -118,6 +135,10 @@ export default {
 .sponsor {
   margin: 1rem;
   height: max-content;
+}
+
+input {
+  background-color: #999999;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
For a variety of reasons, such as being on a locked down corporate computer, not being jailbroken on iOS, or just preferring a browser that happens to not support extensions, some users might not be able to or want to use the extension. So I came up with this addition to the website that lets those users get dislike counts manually in an easier way than using the API.