### PR TITLE
YouTube Shorts now shows dislike counts

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -51,7 +51,7 @@ function isInViewport(element) {
 
 function getButtons() {
   if(isShorts()) {
-    let elements=document.querySelectorAll("#like-button > ytd-like-button-renderer");
+    let elements=document.querySelectorAll(isMobile ? "ytm-like-button-renderer" : "#like-button > ytd-like-button-renderer");
     for(let element of elements) {
       if(isInViewport(element)) {
         return element;
@@ -360,16 +360,20 @@ function setEventListeners(evt) {
   function checkForJS_Finish(check) {
     console.log();
     if (isShorts() || getButtons()?.offsetParent && isVideoLoaded()) {
-      clearInterval(jsInitChecktimer);
       const buttons = getButtons();
 
       if (!window.returnDislikeButtonlistenersSet) {
         cLog("Registering button listeners...");
-        buttons.children[0].addEventListener("click", likeClicked);
-        buttons.children[1].addEventListener("click", dislikeClicked);
+        try {
+          buttons.children[0].addEventListener("click", likeClicked);
+          buttons.children[1].addEventListener("click", dislikeClicked);
+          buttons.children[0].addEventListener("touchstart", likeClicked);
+          buttons.children[1].addEventListener("touchstart", dislikeClicked);
+        } catch { return } //Don't spam errors into the console
         window.returnDislikeButtonlistenersSet = true;
       }
       setInitialState();
+      clearInterval(jsInitChecktimer);
     }
   }
 

--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -30,13 +30,34 @@ let likesvalue = 0;
 let dislikesvalue = 0;
 
 let isMobile = location.hostname == "m.youtube.com";
+let isShorts = () => location.pathname.startsWith("/shorts")
 let mobileDislikes = 0;
 function cLog(text, subtext = "") {
   subtext = subtext.trim() === "" ? "" : `(${subtext})`;
   console.log(`[Return YouTube Dislikes] ${text} ${subtext}`);
 }
 
+function isInViewport(element) {
+  const rect = element.getBoundingClientRect();
+  const height = innerHeight || document.documentElement.clientHeight;
+  const width = innerWidth || document.documentElement.clientWidth;
+  return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <= height &&
+      rect.right <= width
+  );
+}
+
 function getButtons() {
+  if(isShorts()) {
+    let elements=document.querySelectorAll("#like-button > ytd-like-button-renderer");
+    for(let element of elements) {
+      if(isInViewport(element)) {
+        return element;
+      }
+    }
+  }
   if (isMobile) {
     return document.querySelector(".slim-video-action-bar-actions");
   }
@@ -214,6 +235,7 @@ function createRateBar(likes, dislikes) {
   }
 }
 
+
 function setState() {
   cLog("Fetching votes...");
   let statsSet = false;
@@ -232,7 +254,6 @@ function setState() {
       }
     });
   });
-  setState = function(){};
 }
 
 function likeClicked() {
@@ -288,6 +309,9 @@ function getVideoId() {
   if (pathname.startsWith("/clip")) {
     return document.querySelector("meta[itemprop='videoId']").content;
   } else {
+    if (pathname.startsWith("/shorts")) {
+      return pathname.substr(8);
+    }
     return urlObject.searchParams.get("v");
   }
 }
@@ -335,7 +359,7 @@ function setEventListeners(evt) {
 
   function checkForJS_Finish(check) {
     console.log();
-    if (getButtons()?.offsetParent && isVideoLoaded()) {
+    if (isShorts() || getButtons()?.offsetParent && isVideoLoaded()) {
       clearInterval(jsInitChecktimer);
       const buttons = getButtons();
 

--- a/Extensions/combined/ryd.content-script.js
+++ b/Extensions/combined/ryd.content-script.js
@@ -9,6 +9,7 @@ import {
 //---   Import State Functions   ---//
 import {
   isMobile,
+  isShorts,
   isVideoDisliked,
   isVideoLiked,
   getState,
@@ -35,7 +36,7 @@ let jsInitChecktimer = null;
 
 function setEventListeners(evt) {
   function checkForJS_Finish() {
-    if (getButtons()?.offsetParent && isVideoLoaded()) {
+    if (isShorts() || getButtons()?.offsetParent && isVideoLoaded()) {
       clearInterval(jsInitChecktimer);
       jsInitChecktimer = null;
       addLikeDislikeEventListener();

--- a/Extensions/combined/ryd.content-script.js
+++ b/Extensions/combined/ryd.content-script.js
@@ -37,11 +37,11 @@ let jsInitChecktimer = null;
 function setEventListeners(evt) {
   function checkForJS_Finish() {
     if (isShorts() || getButtons()?.offsetParent && isVideoLoaded()) {
-      clearInterval(jsInitChecktimer);
-      jsInitChecktimer = null;
       addLikeDislikeEventListener();
       setInitialState();
       getBrowser().storage.onChanged.addListener(storageChangeHandler);
+      clearInterval(jsInitChecktimer);
+      jsInitChecktimer = null;
     }
   }
 

--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -1,5 +1,5 @@
 import { getButtons } from "./buttons";
-import { likesDisabledState } from "./state";
+import { isMobile, likesDisabledState } from "./state";
 import { cLog } from "./utils";
 
 function createRateBar(likes, dislikes) {

--- a/Extensions/combined/src/buttons.js
+++ b/Extensions/combined/src/buttons.js
@@ -1,6 +1,19 @@
-import { isMobile } from "./state";
+import { isMobile, isShorts } from "./state";
+import { isInViewport } from "./utils";
 
 function getButtons() {
+  //---   If Watching Youtube Shorts:   ---//
+  if(isShorts()) {
+    let elements=document.querySelectorAll("#like-button > ytd-like-button-renderer")
+    for(let element of elements) {
+      //Youtube Shorts can have multiple like/dislike buttons when scrolling through videos
+      //However, only one of them should be visible (no matter how you zoom)
+      if(isInViewport(element)) {
+        return element;
+      }
+    }
+  }
+  //---   If Watching On Mobile:   ---//
   if (isMobile()) {
     return document.querySelector(".slim-video-action-bar-actions");
   }

--- a/Extensions/combined/src/buttons.js
+++ b/Extensions/combined/src/buttons.js
@@ -4,7 +4,7 @@ import { isInViewport } from "./utils";
 function getButtons() {
   //---   If Watching Youtube Shorts:   ---//
   if(isShorts()) {
-    let elements=document.querySelectorAll("#like-button > ytd-like-button-renderer")
+    let elements=document.querySelectorAll(isMobile() ? "ytm-like-button-renderer" : "#like-button > ytd-like-button-renderer"); 
     for(let element of elements) {
       //Youtube Shorts can have multiple like/dislike buttons when scrolling through videos
       //However, only one of them should be visible (no matter how you zoom)

--- a/Extensions/combined/src/events.js
+++ b/Extensions/combined/src/events.js
@@ -100,6 +100,8 @@ function addLikeDislikeEventListener() {
   if (!window.returnDislikeButtonlistenersSet) {
     buttons.children[0].addEventListener("click", likeClicked);
     buttons.children[1].addEventListener("click", dislikeClicked);
+    buttons.children[0].addEventListener("touchstart", likeClicked);
+    buttons.children[1].addEventListener("touchstart", dislikeClicked);
     window.returnDislikeButtonlistenersSet = true;
   }
 }

--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -27,6 +27,10 @@ function isMobile() {
   return location.hostname == "m.youtube.com";
 }
 
+function isShorts() {
+  return location.pathname.startsWith("/shorts")
+}
+
 function isVideoLiked() {
   if (isMobile()) {
     return (
@@ -85,6 +89,11 @@ function setDislikes(dislikesCount) {
 }
 
 function getLikeCountFromButton() {
+  if(isShorts()) {
+    //Youtube Shorts don't work with this query. It's not nessecary; we can skip it and still see the results.
+    //It should be possible to fix this function, but it's not critical to showing the dislike count.
+    return 0;
+  }
   let likesStr = getLikeButton()
     .querySelector("button")
     .getAttribute("aria-label")
@@ -156,6 +165,7 @@ function initializeDisableVoteSubmission() {
 
 export {
   isMobile,
+  isShorts,
   isVideoDisliked,
   isVideoLiked,
   getState,

--- a/Extensions/combined/src/utils.js
+++ b/Extensions/combined/src/utils.js
@@ -45,8 +45,23 @@ function getVideoId(url) {
   if (pathname.startsWith("/clip")) {
     return document.querySelector("meta[itemprop='videoId']").content;
   } else {
+    if (pathname.startsWith("/shorts")) {
+      return pathname.substr(8);
+    }
     return urlObject.searchParams.get("v");
   }
+}
+
+function isInViewport(element) {
+  const rect = element.getBoundingClientRect();
+  const height = innerHeight || document.documentElement.clientHeight;
+  const width = innerWidth || document.documentElement.clientWidth;
+  return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <= height &&
+      rect.right <= width
+  );
 }
 
 function isVideoLoaded() {
@@ -67,4 +82,4 @@ function cLog(message, writer) {
   }
 }
 
-export { numberFormat, getBrowser, getVideoId, isVideoLoaded, cLog }
+export { numberFormat, getBrowser, getVideoId, isInViewport, isVideoLoaded, cLog }


### PR DESCRIPTION
The current version of this extension doesn't work with YouTube Shorts. It shows this:

<img width="1440" alt="Screen Shot 2022-03-18 at 5 51 47 PM" src="https://user-images.githubusercontent.com/17944835/159088698-a3ab9e73-7e2c-421a-8227-9fa2a43f03e1.png">

This commit allows dislike counts to be shown in YouTube Shorts. With this change, it now looks like this:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/17944835/159088981-d73b3f10-4f05-4334-849a-5c34a8828184.png">

Note: It is important that we add this feature, becuase YouTube is now forcibly converting short videos into YouTube shorts. Many videos that are under a minute long on my channel have been turned into YouTube Short videos (such as [this video](https://www.youtube.com/shorts/eDbfVg7R_JA)). There's no option to turn that off in the creator studio, which means many videos that used to display dislikes with this plugin no longer do (without this PR).

This pull request addresses two issues:
https://github.com/Anarios/return-youtube-dislike/issues/382
https://github.com/Anarios/return-youtube-dislike/issues/484