### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -313,7 +313,7 @@ function getVideoId() {
     return document.querySelector("meta[itemprop='videoId']").content;
   } else {
     if (pathname.startsWith("/shorts")) {
-      return pathname.substr(8);
+      return pathname.slice(8);
     }
     return urlObject.searchParams.get("v");
   }

--- a/Extensions/combined/src/utils.js
+++ b/Extensions/combined/src/utils.js
@@ -79,7 +79,7 @@ function getVideoId(url) {
     return document.querySelector("meta[itemprop='videoId']").content;
   } else {
     if (pathname.startsWith("/shorts")) {
-      return pathname.substr(8);
+      return pathname.slice(8);
     }
     return urlObject.searchParams.get("v");
   }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.