### PR TITLE
Removed popup on update/install

### DIFF
--- a/Extensions/combined/manifest-chrome.json
+++ b/Extensions/combined/manifest-chrome.json
@@ -15,9 +15,6 @@
   "permissions": [
     "storage"
   ],
-  "action": {
-    "default_popup": "popup.html"
-  },
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
Popup on update/install isn't really necessary unless there's a major & important announcement to make. We can add it later, when it is actually needed.

resolves #534