### PR TITLE
Remove annoying whats new tab on update.

### DIFF
--- a/Extensions/combined/ryd.background.js
+++ b/Extensions/combined/ryd.background.js
@@ -74,10 +74,6 @@ api.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 });
 
-api.runtime.onInstalled.addListener(() => {
-  api.tabs.create({url: api.runtime.getURL("/changelog/3/changelog_3.0.html")});
-})
-
 async function sendVote(videoId, vote) {
   api.storage.sync.get(null, async (storageResult) => {
     if (!storageResult.userId || !storageResult.registrationConfirmed) {


### PR DESCRIPTION
No, fuck you. NO.

I do not want to be spammed by new tabs by all 50 million extensions I have every time i open chrome. It seems like nothing in the isolate but its gets to 3 or 4 extensions opening tabs every day when allowed to run rampant.