### PR TITLE
Opening `changelog_3.0.html` on extension update

### DIFF
--- a/Extensions/combined/ryd.background.js
+++ b/Extensions/combined/ryd.background.js
@@ -74,8 +74,10 @@ api.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 });
 
-api.runtime.onInstalled.addListener(() => {
-  api.tabs.create({url: api.runtime.getURL("/changelog/3/changelog_3.0.html")});
+api.runtime.onInstalled.addListener(({ reason }) => {
+  if (reason === "update") {
+    api.tabs.create({url: api.runtime.getURL("/changelog/3/changelog_3.0.html")});
+  }
 })
 
 async function sendVote(videoId, vote) {


### PR DESCRIPTION
Currently, the HTML page opens every time the extension updates _or_ the browser updates
This PR is for changing this behavior so only when the extension updates, the HTML page will open up