### PR TITLE
Fix userLocales is undefined

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -2,7 +2,7 @@
 // @name         Return YouTube Dislike
 // @namespace    https://www.returnyoutubedislike.com/
 // @homepage     https://www.returnyoutubedislike.com/
-// @version      3.0.0
+// @version      3.0.1
 // @encoding     utf-8
 // @description  Return of the YouTube Dislike, Based off https://www.returnyoutubedislike.com/
 // @icon         https://github.com/Anarios/return-youtube-dislike/raw/main/Icons/Return%20Youtube%20Dislike%20-%20Transparent.png
@@ -441,7 +441,9 @@ function numberFormat(numberState) {
         ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
         ?.getAttribute("href")
     )?.searchParams?.get("locale");
-  } catch {}
+  } catch {
+    userLocales = document.documentElement.lang;
+  }
 
   let numberDisplay;
   if (extConfig.numberDisplayRoundDown === false) {
@@ -449,12 +451,12 @@ function numberFormat(numberState) {
   } else {
     numberDisplay = roundDown(numberState);
   }
-  return getNumberFormatter(extConfig.numberDisplayFormat).format(
+  return getNumberFormatter(extConfig.numberDisplayFormat, userLocales).format(
     numberDisplay
   );
 }
 
-function getNumberFormatter(optionSelect) {
+function getNumberFormatter(optionSelect, userLocales) {
   let formatterNotation;
   let formatterCompactDisplay;
 


### PR DESCRIPTION
With tempermonkey on mobile firefox user.js script returned error:
`userLocales is undefined` which caused dislikes to stay always at 0.

I noticed that variable is not accessible from `getNumberFormatter` function.
I'm not sure if this is the best approach but I've passed  `userLocales` as parameter. 
I've also set `userLocales` to `document.documentElement.lang` if array search fails.