### PR TITLE
Restructure userLocales logic

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -434,32 +434,38 @@ function roundDown(num) {
 }
 
 function numberFormat(numberState) {
-  let userLocales;
-  try {
-    userLocales = new URL(
-      Array.from(document.querySelectorAll("head > link[rel='search']"))
-        ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
-        ?.getAttribute("href")
-    )?.searchParams?.get("locale");
-  } catch {
-    userLocales = document.documentElement.lang;
-  }
-
   let numberDisplay;
   if (extConfig.numberDisplayRoundDown === false) {
     numberDisplay = numberState;
   } else {
     numberDisplay = roundDown(numberState);
   }
-  return getNumberFormatter(extConfig.numberDisplayFormat, userLocales).format(
+  return getNumberFormatter(extConfig.numberDisplayFormat).format(
     numberDisplay
   );
 }
 
-function getNumberFormatter(optionSelect, userLocales) {
+function getNumberFormatter(optionSelect) {
+  let userLocales;
+  if (document.documentElement.lang) {
+    userLocales = document.documentElement.lang;
+  } else if (navigator.language) {
+    userLocales = navigator.language;
+  } else {
+    try {
+      userLocales = new URL(
+        Array.from(document.querySelectorAll("head > link[rel='search']"))
+          ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
+          ?.getAttribute("href")
+      )?.searchParams?.get("locale");
+    } catch {
+      cLog('Cannot find browser locale. Use en as default for number formatting.');
+      userLocales = 'en';
+    }
+  }
+
   let formatterNotation;
   let formatterCompactDisplay;
-
   switch (optionSelect) {
     case "compactLong":
       formatterNotation = "compact";
@@ -476,7 +482,7 @@ function getNumberFormatter(optionSelect, userLocales) {
   }
 
   const formatter = Intl.NumberFormat(
-    document.documentElement.lang || userLocales || navigator.language,
+    userLocales,
     {
       notation: formatterNotation,
       compactDisplay: formatterCompactDisplay,

--- a/Extensions/combined/src/utils.js
+++ b/Extensions/combined/src/utils.js
@@ -9,15 +9,6 @@ function roundDown(num) {
 }
 
 function numberFormat(numberState) {
-  let userLocales;
-  try {
-    userLocales = new URL(
-      Array.from(document.querySelectorAll("head > link[rel='search']"))
-        ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
-        ?.getAttribute("href")
-    )?.searchParams?.get("locale");
-  } catch {}
-
   let numberDisplay;
   if (extConfig.numberDisplayRoundDown === false) {
     numberDisplay = numberState;
@@ -29,22 +20,27 @@ function numberFormat(numberState) {
   );
 }
 
-function localize(localeString) {
-  return chrome.i18n.getMessage(localeString);
-}
-
 function getNumberFormatter(optionSelect) {
+  let userLocales;
+  if (document.documentElement.lang) {
+    userLocales = document.documentElement.lang;
+  } else if (navigator.language) {
+    userLocales = navigator.language;
+  } else {
+    try {
+      userLocales = new URL(
+        Array.from(document.querySelectorAll("head > link[rel='search']"))
+          ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
+          ?.getAttribute("href")
+      )?.searchParams?.get("locale");
+    } catch {
+      cLog('Cannot find browser locale. Use en as default for number formatting.');
+      userLocales = 'en';
+    }
+  }
+
   let formatterNotation;
   let formatterCompactDisplay;
-  let userLocales;
-  try {
-    userLocales = new URL(
-      Array.from(document.querySelectorAll("head > link[rel='search']"))
-      ?.find((n) => n?.getAttribute("href")?.includes("?locale="))
-      ?.getAttribute("href")
-    )?.searchParams?.get("locale");
-  } catch {}
-
   switch (optionSelect) {
     case "compactLong":
       formatterNotation = "compact";
@@ -61,13 +57,17 @@ function getNumberFormatter(optionSelect) {
   }
 
   const formatter = Intl.NumberFormat(
-    document.documentElement.lang || userLocales || navigator.language,
+    userLocales,
     {
       notation: formatterNotation,
       compactDisplay: formatterCompactDisplay,
     }
   );
   return formatter;
+}
+
+function localize(localeString) {
+  return chrome.i18n.getMessage(localeString);
 }
 
 function getBrowser() {


### PR DESCRIPTION
- Re-structurenumber formatter functions.
- Use userLocales more properly, so it's never undefined.

In PR #574 It is fixed in a different way. This PR addresses the real problem, and applies to extension, too. 

In #574: 
https://github.com/hyperstown/return-youtube-dislike/blob/4de91a51ce8a7805736e56b123672f1a9228824c/Extensions/UserScript/Return%20Youtube%20Dislike.user.js#L445

https://github.com/hyperstown/return-youtube-dislike/blob/4de91a51ce8a7805736e56b123672f1a9228824c/Extensions/UserScript/Return%20Youtube%20Dislike.user.js#L479

When `document.documentElement.lang` is undefined, *neither* Line 479 or Line 445 will not run as intended. In line 479, both will fail and `navigator.language` will be used.

Closes #579