### PR TITLE
Fix like numbers re-format

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -203,10 +203,10 @@ function getLikeCountFromButton() {
   if (isShorts()) {
     //Youtube Shorts don't work with this query. It's not nessecary; we can skip it and still see the results.
     //It should be possible to fix this function, but it's not critical to showing the dislike count.
-    return 0;
+    return false;
   }
   let likesStr = getLikeButton()
-    .querySelector("button")
+    .querySelector("yt-formatted-string#text")
     .getAttribute("aria-label")
     .replace(/\D/g, "");
   return likesStr.length > 0 ? parseInt(likesStr) : false;
@@ -376,8 +376,6 @@ function likeClicked() {
       const nativeLikes = getLikeCountFromButton();
       if (nativeLikes !== false) {
         setLikes(numberFormat(nativeLikes));
-      } else {
-        setLikes(numberFormat(storedData.likes));
       }
     }
   }
@@ -405,8 +403,6 @@ function dislikeClicked() {
         const nativeLikes = getLikeCountFromButton();
         if (nativeLikes !== false) {
           setLikes(numberFormat(nativeLikes));
-        } else {
-          setLikes(numberFormat(storedData.likes));
         }
       }
     }

--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -372,6 +372,14 @@ function likeClicked() {
       createRateBar(likesvalue, dislikesvalue);
       previousState = 1;
     }
+    if (extConfig.numberDisplayReformatLikes === true) {
+      const nativeLikes = getLikeCountFromButton();
+      if (nativeLikes !== false) {
+        setLikes(numberFormat(nativeLikes));
+      } else {
+        setLikes(numberFormat(storedData.likes));
+      }
+    }
   }
 }
 
@@ -393,6 +401,14 @@ function dislikeClicked() {
       setDislikes(numberFormat(dislikesvalue));
       createRateBar(likesvalue, dislikesvalue);
       previousState = 2;
+      if (extConfig.numberDisplayReformatLikes === true) {
+        const nativeLikes = getLikeCountFromButton();
+        if (nativeLikes !== false) {
+          setLikes(numberFormat(nativeLikes));
+        } else {
+          setLikes(numberFormat(storedData.likes));
+        }
+      }
     }
   }
 }

--- a/Extensions/combined/popup.html
+++ b/Extensions/combined/popup.html
@@ -108,7 +108,7 @@
     <span class="switchLabel">Show rounded down numbers</span>
   </label>
   <br/>
-  <label class="switch" data-hover="Make likes and dislikes format consistent">
+  <label class="switch" data-hover="Make likes and dislikes format consistent (does not work on Shorts)">
     <input type="checkbox" id="number_reformat_likes"/>
     <span class="slider"/>
     <span class="switchLabel">Re-format like numbers</span>

--- a/Extensions/combined/src/events.js
+++ b/Extensions/combined/src/events.js
@@ -8,6 +8,7 @@ import {
   extConfig,
   storedData,
   setLikes,
+  getLikeCountFromButton,
 } from "./state";
 import { createRateBar } from "./bar";
 
@@ -41,6 +42,14 @@ function likeClicked() {
       createRateBar(storedData.likes, storedData.dislikes);
       storedData.previousState = NEUTRAL_STATE;
     }
+    if (extConfig.numberDisplayReformatLikes === true) {
+      const nativeLikes = getLikeCountFromButton();
+      if (nativeLikes !== false) {
+        setLikes(numberFormat(nativeLikes));
+      } else {
+        setLikes(numberFormat(storedData.likes));
+      }
+    }
   }
 }
 
@@ -65,6 +74,14 @@ function dislikeClicked() {
       setDislikes(numberFormat(storedData.dislikes));
       createRateBar(storedData.likes, storedData.dislikes);
       storedData.previousState = DISLIKED_STATE;
+      if (extConfig.numberDisplayReformatLikes === true) {
+        const nativeLikes = getLikeCountFromButton();
+        if (nativeLikes !== false) {
+          setLikes(numberFormat(nativeLikes));
+        } else {
+          setLikes(numberFormat(storedData.likes));
+        }
+      }
     }
   }
 }

--- a/Extensions/combined/src/events.js
+++ b/Extensions/combined/src/events.js
@@ -46,8 +46,6 @@ function likeClicked() {
       const nativeLikes = getLikeCountFromButton();
       if (nativeLikes !== false) {
         setLikes(numberFormat(nativeLikes));
-      } else {
-        setLikes(numberFormat(storedData.likes));
       }
     }
   }
@@ -78,8 +76,6 @@ function dislikeClicked() {
         const nativeLikes = getLikeCountFromButton();
         if (nativeLikes !== false) {
           setLikes(numberFormat(nativeLikes));
-        } else {
-          setLikes(numberFormat(storedData.likes));
         }
       }
     }

--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -150,7 +150,7 @@ function getLikeCountFromButton() {
   if (isShorts()) {
     //Youtube Shorts don't work with this query. It's not nessecary; we can skip it and still see the results.
     //It should be possible to fix this function, but it's not critical to showing the dislike count.
-    return 0;
+    return false;
   }
   let likesStr = getLikeButton()
     .querySelector("yt-formatted-string#text")

--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -153,7 +153,7 @@ function getLikeCountFromButton() {
     return 0;
   }
   let likesStr = getLikeButton()
-    .querySelector("button")
+    .querySelector("yt-formatted-string#text")
     .getAttribute("aria-label")
     .replace(/\D/g, "");
   return likesStr.length > 0 ? parseInt(likesStr) : false;


### PR DESCRIPTION
When like button is clicked, only one of the two aria-label attributes gets updated. Use the correct one to reflect latest like count. Affects user option "re-format like numbers" Related: #561

When like button is clicked, YT will update like count. This conflicts with user option "re-format like numbers". Force update like number. Related: #584

Since official like count is still available, avoid using API server response. Clarify user option re-format like number does not work on Shorts. Related: #581

fixes #605 
fixes #604
probably fix issues #496 and #631 but the issue's OP is not responding for further diagnostic details, so can't be sure

closes #645
closes #647
closes #650