### PR TITLE
Standardization of links to translations in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Return YouTube Dislike
 
-Read this in other languages: [русский](READMEru.md), [Español](READMEes.md), [Türkçe](READMEtr.md)
+Read this in other languages: [Español](READMEes.md), [русский](READMEru.md), [Türkçe](READMEtr.md)
 
 <p align="center">
     <b>Return YouTube Dislike is an open-source extension that returns the YouTube dislike count.</b><br>

--- a/READMEes.md
+++ b/READMEes.md
@@ -9,7 +9,7 @@
 
 # Return YouTube Dislike
 
-Leer en otros idiomas: [English](README.md), [русский](READMEru.md),  [Türkçe](READMEtr.md)
+Leer en otros idiomas: [English](README.md), [русский](READMEru.md), [Türkçe](READMEtr.md)
 
 <p align="center">
     <b>Return YouTube Dislike es una extensión de código abierto que regresa el contador de dislikes.</b><br>

--- a/READMEes.md
+++ b/READMEes.md
@@ -7,10 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Leer en otros idiomas: 
-
 # Return YouTube Dislike
-
 
 Leer en otros idiomas: [English](README.md), [русский](READMEru.md),  [Türkçe](READMEtr.md)
 

--- a/READMEru.md
+++ b/READMEru.md
@@ -11,6 +11,7 @@
 # Return YouTube Dislike
 
 Прочитать на других языках: [English](README.md), [Español](READMEes.md), [Türkçe](READMEtr.md)
+
 <p align="center">
     <b>Return YouTube Dislike - это расширение с открытым исходным кодом, которое возвращает счётчик отметок «Не нравится» на YouTube.</b><br>
     Доступно для Chrome и Firefox в качестве веб-расширения.<br>

--- a/READMEru.md
+++ b/READMEru.md
@@ -10,7 +10,7 @@
 
 # Return YouTube Dislike
 
-Прочитать на других языках: [English](README.md), [Español](READMEes.md)
+Прочитать на других языках: [English](README.md), [Español](READMEes.md), [Türkçe](READMEtr.md)
 <p align="center">
     <b>Return YouTube Dislike - это расширение с открытым исходным кодом, которое возвращает счётчик отметок «Не нравится» на YouTube.</b><br>
     Доступно для Chrome и Firefox в качестве веб-расширения.<br>

--- a/READMEtr.md
+++ b/READMEtr.md
@@ -9,7 +9,7 @@
 
 # YouTube Dislike Sayısını Geri Getir
 
-Bunu diğer dillerde okuyun: [İngilizce](README.md), [İspanyolca](READMEes.md), [Rusça](READMEru.md)
+Bunu diğer dillerde okuyun: [English](README.md), [Español](READMEes.md), [русский](READMEru.md)
 
 <p align="center">
     <b>YouTube Dislike Sayısını Geri Getir, YouTube'daki dislike sayısını gösteren açık-kaynaklı bir uzantıdır.</b><br>

--- a/READMEtr.md
+++ b/READMEtr.md
@@ -7,9 +7,9 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![Lisans](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Bunu diğer dillerde okuyun: [İngilizce](README.md), [İspanyolca](READMEes.md)
-
 # YouTube Dislike Sayısını Geri Getir
+
+Bunu diğer dillerde okuyun: [İngilizce](README.md), [İspanyolca](READMEes.md), [Rusça](READMEru.md)
 
 <p align="center">
     <b>YouTube Dislike Sayısını Geri Getir, YouTube'daki dislike sayısını gösteren açık-kaynaklı bir uzantıdır.</b><br>


### PR DESCRIPTION
## What is standardized :
- Added missing links to other translations. **Solved with #618**
- Moving the links before "Return YouTube Dislike" part if it was not already the case. **Solved with #618**
- Used the name of a language in its language instead of the language of the README: Español instead of Spanish. **Solved with #619**
- Ordering of languages according to their number of speakers : [Ethnologue (2022, 25th edition) on Wikipedia](https://en.wikipedia.org/wiki/List_of_languages_by_total_number_of_speakers#Ethnologue_(2022,_25th_edition)). **Also fix by #617**

_English is not my mother tongue so I'm sorry if I express myself badly._