### PR TITLE
Handle onInstalled.reason "chrome_update"

### DIFF
--- a/Extensions/combined/ryd.background.js
+++ b/Extensions/combined/ryd.background.js
@@ -77,6 +77,8 @@ api.runtime.onInstalled.addListener((details) => {
   if (
     // No need to show changelog if its was a browser update (and not extension update)
     details.reason === "browser_update" ||
+    // Chromium (e.g., Google Chrome Cannary) uses this name instead of the one above for some reason
+    details.reason === "chrome_update" ||
     // No need to show changelog if developer just reloaded the extension
     details.reason === "update"
   )


### PR DESCRIPTION
You can observe this undocumented string by either of two methods:
 - Search for [`ON_INSTALLED_REASON_CHROME_UPDATE`](https://source.chromium.org/chromium/chromium/src/+/main:out/Debug/gen/extensions/common/api/runtime.h;drc=169c6cc102b39295a5bfe2f2a176b42b1c2fe2c4;l=133) on googlesource
 - Create a custom extension and install it Canary which will record onInstalled events and then evaluate them
 Here is the whole extension:
`manifest.json`
```json
{
  "name": "Test",
  "version": "1.0",
  "manifest_version": 3,
  "background": {
    "service_worker": "background.js"
  },
  "action": {},
  "permissions": ["storage"]
}
```
and `background.js`
```
chrome.runtime.onInstalled.addListener((data) => 
  chrome.storage.local.set({[Date.now().toString()]: JSON.stringify(data)})
);
```