### PR TITLE
Add question to gauge the user's interest

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -59,8 +59,8 @@ body:
   attributes:
     label: "Will you be available for follow-up questions to help developers diagnose & fix the issue?"
     options: 
-      - Yes
-      - No
+      - "Yes"
+      - "No"
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report!
-title: "(Bug): "
+# title: "(Bug): "
 labels: ["bug"]
 body:
 - type: input

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -55,4 +55,13 @@ body:
     value: "Tell us how it happened with detailed steps for us."
   validations:
     required: true
+- type: dropdown
+  attributes:
+    label: "Will you be available for follow-up questions to help developers diagnose & fix the issue?"
+    options: 
+      - Yes
+      - No
+  validations:
+    required: true
+
     

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -28,4 +28,12 @@ body:
     options:
       - label: "Yes"
       - label: "No"
+- type: dropdown
+  attributes:
+    label: "Will you be available for follow-up questions to help developers implement this?"
+    options: 
+      - "Yes"
+      - "No"
+  validations:
+    required: true
   

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Request or suggest a new feature!
-title: "(Feature Request): "
+# title: "(Feature Request): "
 labels: ["enhancement"]
 body:
 - type: dropdown


### PR DESCRIPTION
resolves #580 

---

Originally posted by **cyrildtm** May  1, 2022

> At the end of the bug report questionnaire, add a question "Will you be available for follow-up questions and help with developers further diagnose the situation"
> 
> It's frustrating when a user writes a report, and forgets about it. Developers don't always run into the same bug within their usage cases, and the bug reports are not always clear enough for re-creating the problem. With this questionnaire, developers can gauge the user interests and therefore put priorities.
