### PR TITLE
Workflow to assign issue/pull to the commenter

### DIFF
--- a/.github/workflows/assignme.yml
+++ b/.github/workflows/assignme.yml
@@ -1,16 +1,18 @@
-name: Assign issue/pull to the commenter
+name: commentCommands
 
 on:
   issue_comment:
     types: created
     
 jobs:
-  assign:
+
+  assign-commentor:
     runs-on: ubuntu-latest
     if: |
-      github.event.comment.body == '/assignme'
+      contains(github.event.comment.body, '/assignme') ||
+      contains(github.event.comment.body, '/assign me')
     steps:
-      - name: Assigning to commentor
+      - name: Assigning to commenter
         run: |
           curl \
           -X POST \


### PR DESCRIPTION
resolves Anarios/return-youtube-dislike/issues/354

GitHub-Bot assigns the issue to anyone who comments `/assignme`

Should I limit it to owner, collaborators & **contributors** only?