### PR TITLE
Show "Dislike" instead of "disabled by owner"

### DIFF
--- a/Extensions/combined/_locales/en/messages.json
+++ b/Extensions/combined/_locales/en/messages.json
@@ -30,13 +30,13 @@
     "message": "Disable like/dislike submission"
   },
   "textLikesDisabled": {
-    "message": "disabled by owner"
+    "message": "Dislike"
   },
   "textSettingsHover": {
     "message": "Stops counting your likes and dislikes."
   },
   "textTempUnavailable": {
-    "message": "temporarily unavailable"
+    "message": "Temporarily unavailable"
   },
   "textUpdate": {
     "message": "update to"


### PR DESCRIPTION
The idea is to show the "Dislike" text when the Likes/Dislikes are disabled by owner to maintain the vanilla & minimal look of youtube