### PR TITLE
Update SECURITY-FAQfr.md

### DIFF
--- a/Docs/SECURITY-FAQfr.md
+++ b/Docs/SECURITY-FAQfr.md
@@ -2,7 +2,7 @@ Lisez ceci dans d'autres langues : [English](SECURITY-FAQ.md), [русский](
 
 # Sécurité
 
-### Est-ce que vous traquer l'historique des vidéos que je visionne ?
+### Est-ce que vous traquez l'historique des vidéos que je visionne ?
 
 Non. Le code de l'extension est public et vous pouvez le voir par vous-même. La seule information envoyée est l'ID de la vidéo, qui est nécessaire pour récupérer le nombre de dislikes des vidéos. Aucun en-tête (headers) supplémentaire n'est envoyé. Sur la [couche de communication](https://fr.wikipedia.org/wiki/Mod%C3%A8le_OSI#Caract%C3%A9risation_r%C3%A9sum%C3%A9e_des_couches), votre adresse IP publique sera exposée au serveur, ainsi que l'heure à laquelle la demande a été faite. Toutefois, aucun de ces éléments ne permet de vous identifier de manière unique. Dans un environnement où vous ne pouvez avoir confiance en personne (zero-trust environment), le mieux que l'on puisse obtenir est une IP dynamique. Qui, aujourd'hui est la vôtre, demain est celle de votre voisin. Si vous êtes vraiment inquiet que votre IP soit tracée, vous utilisez probablement déjà un VPN.
 


### PR DESCRIPTION
Il convient d'avoir une terminaison en ez, car il s'agit de la deuxième personne du pluriel du verbe traquer.