### PR TITLE
HOTFIX: added aditional check for like/dislike buttons inside ACTIVE …

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -58,6 +58,9 @@ function isInViewport(element) {
   const height = innerHeight || document.documentElement.clientHeight;
   const width = innerWidth || document.documentElement.clientWidth;
   return (
+    // When short (channel) is ignored, the element (like/dislike AND short itself) is
+    // hidden with a 0 DOMRect. In this case, consider it outside of Viewport
+    !(rect.top == 0 && rect.left == 0 && rect.bottom == 0 && rect.right == 0) &&
     rect.top >= 0 &&
     rect.left >= 0 &&
     rect.bottom <= height &&

--- a/Extensions/combined/src/utils.js
+++ b/Extensions/combined/src/utils.js
@@ -87,6 +87,9 @@ function isInViewport(element) {
   const height = innerHeight || document.documentElement.clientHeight;
   const width = innerWidth || document.documentElement.clientWidth;
   return (
+    // When short (channel) is ignored, the element (like/dislike AND short itself) is
+    // hidden with a 0 DOMRect. In this case, consider it outside of Viewport
+    !(rect.top == 0 && rect.left == 0 && rect.bottom == 0 && rect.right == 0) &&
     rect.top >= 0 &&
     rect.left >= 0 &&
     rect.bottom <= height &&


### PR DESCRIPTION
Fixes #741 

In certain cases (see [issue #741](https://github.com/Anarios/return-youtube-dislike/issues/741)), the dislike number would not be updated in following Shorts. This would happen because the updated HTML element being updated was the wrong one.

---

After some debbuging time, I found the issue in the ```getButtons()``` function, more specifically:

```javascript
    for (let element of elements) {
      //Youtube Shorts can have multiple like/dislike buttons when scrolling through videos
      //However, only one of them should be visible (no matter how you zoom)
      if (isInViewport(element)) {
        return element;
      }
    }
```

while iterating through the list of like/dislike buttons in the Shorts page, the wrong ```element``` was always being chosen after ignoring some channel (following the Issue's description). This happened because the ```isInViewport()``` function would always return true for one "_element_" (button) previous to the one currently shown.

The reason these previous ones were considered "in the viewport" is because the current logic of this function:

```javascript
function isInViewport(element) {
  const rect = element.getBoundingClientRect();
  const height = innerHeight || document.documentElement.clientHeight;
  const width = innerWidth || document.documentElement.clientWidth;
  return (
    rect.top >= 0 &&
    rect.left >= 0 &&
    rect.bottom <= height &&
    rect.right <= width
  );
}
```

would see a DOMRect for these these previous buttons with ```top```, ```left```, ```bottom``` and ```right``` attributes equal to **0**, thus always returning true for these kind of elements. It appears this happens with _ignored Shorts_ because they are effectively **hidden** (in CSS) and reduced to 0-lenght box.

---

A possible fix would be to detect these hidden tags (as the actually hidden elements are these buttons' parent nodes), or changing some of the current checks in the function above in some way, but the change below seemed to suffice and work both in the browser versions of the extension:

```diff
diff --git a/Extensions/combined/src/utils.js b/Extensions/combined/src/utils.js
index b92bc0c..e789815 100644
--- a/Extensions/combined/src/utils.js
+++ b/Extensions/combined/src/utils.js
@@ -87,6 +87,9 @@ function isInViewport(element) {
   const height = innerHeight || document.documentElement.clientHeight;
   const width = innerWidth || document.documentElement.clientWidth;
   return (
+    // When short (channel) is ignored, the element (like/dislike AND short itself) is
+    // hidden with a 0 DOMRect. In this case, consider it outside of Viewport
+    !(rect.top == 0 && rect.left == 0 && rect.bottom == 0 && rect.right == 0) &&
     rect.top >= 0 &&
     rect.left >= 0 &&
     rect.bottom <= height &&

```