### PR TITLE
QFIX hidden dislike count, extension & userjs

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -219,6 +219,7 @@ function setDislikes(dislikesCount) {
     mobileDislikes = dislikesCount;
     return;
   }
+  getDislikeTextContainer()?.removeAttribute('is-empty');
   getDislikeTextContainer().innerText = dislikesCount;
 }
 

--- a/Extensions/combined/manifest-chrome.json
+++ b/Extensions/combined/manifest-chrome.json
@@ -2,7 +2,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "3.0.0.4",
+  "version": "3.0.0.5",
   "manifest_version": 3,
   "background": {
     "service_worker": "ryd.background.js"

--- a/Extensions/combined/manifest-firefox.json
+++ b/Extensions/combined/manifest-firefox.json
@@ -2,7 +2,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "3.0.0.5",
+  "version": "3.0.0.6",
   "manifest_version": 2,
   "background": {
     "scripts": ["ryd.background.js"]

--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -137,6 +137,7 @@ function setLikes(likesCount) {
 }
 
 function setDislikes(dislikesCount) {
+  getDislikeTextContainer()?.removeAttribute('is-empty');
   if (!isLikesDisabled()) {
     if (isMobile()) {
       getButtons().children[1].querySelector(


### PR DESCRIPTION
Fixes #757

In some cases dislike count was hidden from the user. YT added attribute `is-empty` that had CSS property `display: none`
![image](https://user-images.githubusercontent.com/64496017/190897858-07ffc8e5-2870-4163-afbf-2fbf08d278a9.png)
![image](https://user-images.githubusercontent.com/64496017/190897863-d3c09381-3b5f-4046-9679-7d79a54fa8c7.png)

I've added `getDislikeTextContainer()?.removeAttribute('is-empty');` to `setDislikes()`

Other possible solutions would be to set css property.

Fix tested with both extension and userscript 