### PR TITLE
FIX: Dislike button displaying "Dislike" text next to count

### DIFF
--- a/Extensions/combined/src/buttons.js
+++ b/Extensions/combined/src/buttons.js
@@ -56,7 +56,8 @@ function getDislikeButton() {
 function getDislikeTextContainer() {
   let result =
     getDislikeButton().querySelector("#text") ??
-    getDislikeButton().getElementsByTagName("yt-formatted-string")[0];
+    getDislikeButton().getElementsByTagName("yt-formatted-string")[0] ??
+    getDislikeButton().querySelector("span[role='text']");
   if (result == null) {
     let textSpan = document.createElement("span");
     textSpan.id = "text";


### PR DESCRIPTION
Fixes #742, #752

New design now has replaced `id='text'` with an attribute `text`. 

`getDislikeTextContainer()` could not find dislike container since it was looking for ID or specific tag name add added additional span with dislike number.

I've added additional `querySelector` that checks for that attribute as well.

UserScript has this already implemented in my previous PR.