### PR TITLE
Fix reformat likes

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -100,7 +100,8 @@ function getLikeButton() {
 function getLikeTextContainer() {
   return (
     getLikeButton().querySelector("#text") ??
-    getLikeButton().getElementsByTagName("yt-formatted-string")[0]
+    getLikeButton().getElementsByTagName("yt-formatted-string")[0] ??
+    getLikeButton().querySelector("span[role='text']")
   );
 }
 
@@ -227,16 +228,24 @@ function setDislikes(dislikesCount) {
 }
 
 function getLikeCountFromButton() {
-  if (isShorts()) {
-    //Youtube Shorts don't work with this query. It's not nessecary; we can skip it and still see the results.
-    //It should be possible to fix this function, but it's not critical to showing the dislike count.
+  try {
+    if (isShorts()) {
+      //Youtube Shorts don't work with this query. It's not necessary; we can skip it and still see the results.
+      //It should be possible to fix this function, but it's not critical to showing the dislike count.
+      return false;
+    }
+    let likeButton = getLikeButton()
+    .querySelector("yt-formatted-string#text") ??
+    getLikeButton().querySelector("button");
+
+    let likesStr = likeButton.getAttribute("aria-label")
+    .replace(/\D/g, "");
+    return likesStr.length > 0 ? parseInt(likesStr) : false;
+  }
+  catch {
     return false;
   }
-  let likesStr = getLikeButton()
-    .querySelector("yt-formatted-string#text")
-    .getAttribute("aria-label")
-    .replace(/\D/g, "");
-  return likesStr.length > 0 ? parseInt(likesStr) : false;
+
 }
 
 (typeof GM_addStyle != "undefined"

--- a/Extensions/combined/manifest-chrome.json
+++ b/Extensions/combined/manifest-chrome.json
@@ -2,7 +2,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "3.0.0.5",
+  "version": "3.0.0.6",
   "manifest_version": 3,
   "background": {
     "service_worker": "ryd.background.js"

--- a/Extensions/combined/manifest-firefox.json
+++ b/Extensions/combined/manifest-firefox.json
@@ -2,7 +2,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "3.0.0.6",
+  "version": "3.0.0.7",
   "manifest_version": 2,
   "background": {
     "scripts": ["ryd.background.js"]

--- a/Extensions/combined/src/buttons.js
+++ b/Extensions/combined/src/buttons.js
@@ -24,7 +24,7 @@ function getButtons() {
   //---   If Menu Element Is Displayed:   ---//
   if (document.getElementById("menu-container")?.offsetParent === null) {
     return document.querySelector("ytd-menu-renderer.ytd-watch-metadata > div");
-    //---   If Menu Element Isnt Displayed:   ---//
+    //---   If Menu Element Isn't Displayed:   ---//
   } else {
     return document
       .getElementById("menu-container")
@@ -42,7 +42,8 @@ function getLikeButton() {
 function getLikeTextContainer() {
   return (
     getLikeButton().querySelector("#text") ??
-    getLikeButton().getElementsByTagName("yt-formatted-string")[0]
+    getLikeButton().getElementsByTagName("yt-formatted-string")[0] ??
+    getLikeButton().querySelector("span[role='text']")
   );
 }
 

--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -133,10 +133,12 @@ function getState(storedData) {
 
 //---   Sets The Likes And Dislikes Values   ---//
 function setLikes(likesCount) {
+  cLog(`SET likes ${likesCount}`)
   getLikeTextContainer().innerText = likesCount;
 }
 
 function setDislikes(dislikesCount) {
+  cLog(`SET dislikes ${dislikesCount}`)
   getDislikeTextContainer()?.removeAttribute('is-empty');
   if (!isLikesDisabled()) {
     if (isMobile()) {
@@ -161,13 +163,15 @@ function setDislikes(dislikesCount) {
 function getLikeCountFromButton() {
   try {
     if (isShorts()) {
-      //Youtube Shorts don't work with this query. It's not nessecary; we can skip it and still see the results.
+      //Youtube Shorts don't work with this query. It's not necessary; we can skip it and still see the results.
       //It should be possible to fix this function, but it's not critical to showing the dislike count.
       return false;
     }
-    let likesStr = getLikeButton()
-    .querySelector("yt-formatted-string#text")
-    .getAttribute("aria-label")
+    let likeButton = getLikeButton()
+    .querySelector("yt-formatted-string#text") ??
+    getLikeButton().querySelector("button");
+
+    let likesStr = likeButton.getAttribute("aria-label")
     .replace(/\D/g, "");
     return likesStr.length > 0 ? parseInt(likesStr) : false;
   }
@@ -191,7 +195,7 @@ function processResponse(response, storedData) {
   createRateBar(storedData.likes, storedData.dislikes);
   if (extConfig.coloredThumbs === true) {
     if (isShorts()) {
-      // for shorts, leave deactived buttons in default color
+      // for shorts, leave deactivated buttons in default color
       let shortLikeButton = getLikeButton().querySelector(
         "tp-yt-paper-button#button"
       );


### PR DESCRIPTION
Fixes #772

New design now removed `aria-label` that contained likes number. New source of likes is now in the button element.

`getLikeTextContainer()` could not find like container since it was looking for ID or specific tag name.

I've added additional querySelector that checks for role attributes as well.

![image](https://user-images.githubusercontent.com/64496017/196298148-15c12b5a-3ace-4879-aa32-1dc92d691cbf.png)

