### PR TITLE
GitHub Issues: Ensuring a bug report is not a duplicate on the first stage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,6 +3,12 @@ description: File a bug report!
 # title: "(Bug): "
 labels: ["bug"]
 body:
+  - type: checkboxes
+    attributes:
+      label: Have you tried to find similar open issues?
+      options:
+        - label: "Yes, this issue is not a duplicate"
+          required: true
   - type: input
     attributes:
       label: Browser


### PR DESCRIPTION
Wanted to add it at the bottom at first, then thought about potential time waste for those who file an issue and it ends up being a duplicate - it's better to keep it at the top