### PR TITLE
Fix "API down" error message

### DIFF
--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -223,7 +223,7 @@ function processResponse(response, storedData) {
 
 // Tells the user if the API is down
 function displayError(error) {
-  getButtons().children[1].querySelector("#text").innerText = localize(
+  getDislikeTextContainer().innerText = localize(
     "textTempUnavailable"
   );
 }


### PR DESCRIPTION
Hi, I fixed invalid query selector in `displayError` function. Now it shows error message.

![image](https://user-images.githubusercontent.com/64496017/200650051-c0e2dbbd-2099-4b56-b095-e10b4c48d9e8.png)

