### PR TITLE
Dislike text disabled on click fix.

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -2,7 +2,7 @@
 // @name         Return YouTube Dislike
 // @namespace    https://www.returnyoutubedislike.com/
 // @homepage     https://www.returnyoutubedislike.com/
-// @version      3.1.0
+// @version      3.1.1
 // @encoding     utf-8
 // @description  Return of the YouTube Dislike, Based off https://www.returnyoutubedislike.com/
 // @icon         https://github.com/Anarios/return-youtube-dislike/raw/main/Icons/Return%20Youtube%20Dislike%20-%20Transparent.png
@@ -635,10 +635,10 @@ function setEventListeners(evt) {
       if (!window.returnDislikeButtonlistenersSet) {
         cLog("Registering button listeners...");
         try {
-          buttons.children[0].addEventListener("click", likeClicked);
-          buttons.children[1].addEventListener("click", dislikeClicked);
-          buttons.children[0].addEventListener("touchstart", likeClicked);
-          buttons.children[1].addEventListener("touchstart", dislikeClicked);
+          buttons.children[0].children[0].addEventListener("click", likeClicked);
+          buttons.children[0].children[1].addEventListener("click", dislikeClicked);
+          buttons.children[0].children[0].addEventListener("touchstart", likeClicked);
+          buttons.children[0].children[1].addEventListener("touchstart", dislikeClicked);
         } catch {
           return;
         } //Don't spam errors into the console


### PR DESCRIPTION
The dislike number text got disabled whenever we clicked on the dislike button, it was because the addEventListener wasn't being attached to the correct like and dislike buttons (new).

Tested in chrome windows 11, version: 107.0.5304.107

|    |  Before clicking dislike| After clicking dislike| 
| :---: | :---:        |     :---:      |  
|   Previously | ![image](https://user-images.githubusercontent.com/29508236/202921427-b66aa6c9-3d83-400e-8b93-8a113a6a71a9.png)   | ![image](https://user-images.githubusercontent.com/29508236/202921242-a71f10e3-fe70-460b-a8b9-f7528f872bcb.png)     |
|   Now (In this commit) | ![image](https://user-images.githubusercontent.com/29508236/202921427-b66aa6c9-3d83-400e-8b93-8a113a6a71a9.png)   | ![image](https://user-images.githubusercontent.com/29508236/202921318-ed2564c9-d23a-4c0f-8cb6-b1cdc1205782.png)     |
