### PR TITLE
Fix disappearing rate bar

### DIFF
--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -14,7 +14,6 @@ function createRateBar(likes, dislikes) {
   if (!isLikesDisabled()) {
     // sometimes rate bar is hidden
     if(rateBar && !isInViewport(rateBar)){
-      cLog('create rateBar remove old')
       rateBar.remove();
       rateBar = null;
     }

--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -10,11 +10,9 @@ import {
 import { cLog, getColorFromTheme } from "./utils";
 
 function createRateBar(likes, dislikes) {
-  let ratebar = document.getElementById("ryd-bar-container");
-  if (ratebar) {
-    ratebar.parentNode.removeChild(ratebar);
-  }
   if (!isLikesDisabled()) {
+    let rateBar = document.getElementById("ryd-bar-container");
+
     const widthPx =
       getLikeButton().clientWidth +
       getDislikeButton().clientWidth +
@@ -50,7 +48,7 @@ function createRateBar(likes, dislikes) {
     }
 
     if (!isShorts()) {
-      if (!isMobile()) {
+      if (!rateBar && !isMobile()) {
         let colorLikeStyle = "";
         let colorDislikeStyle = "";
         if (extConfig.coloredBar) {
@@ -111,6 +109,12 @@ function createRateBar(likes, dislikes) {
             getColorFromTheme(true);
         }
       }
+    }
+  } else {
+    cLog("removing bar");
+    let ratebar = document.getElementById("ryd-bar-container");
+    if (ratebar) {
+      ratebar.parentNode.removeChild(ratebar);
     }
   }
 }

--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -10,9 +10,11 @@ import {
 import { cLog, getColorFromTheme } from "./utils";
 
 function createRateBar(likes, dislikes) {
+  let ratebar = document.getElementById("ryd-bar-container");
+  if (ratebar) {
+    ratebar.parentNode.removeChild(ratebar);
+  }
   if (!isLikesDisabled()) {
-    let rateBar = document.getElementById("ryd-bar-container");
-
     const widthPx =
       getLikeButton().clientWidth +
       getDislikeButton().clientWidth +
@@ -48,7 +50,7 @@ function createRateBar(likes, dislikes) {
     }
 
     if (!isShorts()) {
-      if (!rateBar && !isMobile()) {
+      if (!isMobile()) {
         let colorLikeStyle = "";
         let colorDislikeStyle = "";
         if (extConfig.coloredBar) {
@@ -109,12 +111,6 @@ function createRateBar(likes, dislikes) {
             getColorFromTheme(true);
         }
       }
-    }
-  } else {
-    cLog("removing bar");
-    let ratebar = document.getElementById("ryd-bar-container");
-    if (ratebar) {
-      ratebar.parentNode.removeChild(ratebar);
     }
   }
 }

--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -7,11 +7,17 @@ import {
   isRoundedDesign,
   isShorts,
 } from "./state";
-import { cLog, getColorFromTheme } from "./utils";
+import { cLog, getColorFromTheme, isInViewport } from "./utils";
 
 function createRateBar(likes, dislikes) {
+  let rateBar = document.getElementById("ryd-bar-container");
   if (!isLikesDisabled()) {
-    let rateBar = document.getElementById("ryd-bar-container");
+    // sometimes rate bar is hidden
+    if(rateBar && !isInViewport(rateBar)){
+      cLog('create rateBar remove old')
+      rateBar.remove();
+      rateBar = null;
+    }
 
     const widthPx =
       getLikeButton().clientWidth +
@@ -55,11 +61,10 @@ function createRateBar(likes, dislikes) {
           colorLikeStyle = "; background-color: " + getColorFromTheme(true);
           colorDislikeStyle = "; background-color: " + getColorFromTheme(false);
         }
-
+        let actions = isNewDesign() && getButtons().id === "top-level-buttons-computed" 
+          ? getButtons() : document.getElementById("menu-container");
         (
-          document.getElementById(
-            isNewDesign() ? "top-level-buttons-computed" : "menu-container"
-          ) || document.querySelector("ytm-slim-video-action-bar-renderer")
+          actions || document.querySelector("ytm-slim-video-action-bar-renderer")
         ).insertAdjacentHTML(
           "beforeend",
           `
@@ -112,9 +117,8 @@ function createRateBar(likes, dislikes) {
     }
   } else {
     cLog("removing bar");
-    let ratebar = document.getElementById("ryd-bar-container");
-    if (ratebar) {
-      ratebar.parentNode.removeChild(ratebar);
+    if (rateBar) {
+      rateBar.parentNode.removeChild(rateBar);
     }
   }
 }


### PR DESCRIPTION
Hi, I've noticed that ratio bar disappears when youtube uses it's push history (doesn't load whole website from zero).
It turns out that it doesn't actually disappears but its being pushed outside visible canvas. The way youtube updates DOM, ratio bar is somewhere inside hidden elements.

Currently rateBar function just checks if rateBar `div` exists and updates it if it does.
But if rateBar is outside visible canvas update is pointless.

```js 
let rateBar = document.getElementById("ryd-bar-container");
```
![image](https://user-images.githubusercontent.com/64496017/203530565-08d58727-3226-43c4-affc-e918b89130be.png)
(Firefox grays out invisible elements in inspector)
![image](https://user-images.githubusercontent.com/64496017/203530690-5f63af32-cec0-44d8-a987-42db496d6345.png)


I've added additional check that ensures rateBar is visible. If not. Removes old bar and adds a new one.
```js
if(rateBar && !isInViewport(rateBar)){
      rateBar.remove();
      rateBar = null;
    }
```
Second issue was that rateBar position selector found invisible buttons container before actual one.
 `getElementById()` assumes that ID is unique per page so it returns first element that matches. Unfortunately  youtube has multiples IDs with the same name. Just one of them is visible though.

```js
document.getElementById(
            isNewDesign() ? "top-level-buttons-computed" : "menu-container"
 ) || document.querySelector("ytm-slim-video-action-bar-renderer")
 ```

![image](https://user-images.githubusercontent.com/64496017/203531653-1cadc571-da82-4723-a528-7b93e9f883ac.png)

I could iterate every element and check if is visible but in new design we already have good working selector that returns `top-level-buttons-computed` id. `getButtons`

I've added this selector:
```js
let actions = isNewDesign() && getButtons().id === "top-level-buttons-computed" 
          ? getButtons() : document.getElementById("menu-container");
actions || document.querySelector("ytm-slim-video-action-bar-renderer")
```
Perhaps we could remove `&& getButtons().id === "top-level-buttons-computed" ` but the way youtube handles everything I don't know if that's a good idea.

Result:

![image](https://user-images.githubusercontent.com/64496017/203532944-8558a837-de2d-4f1a-925b-4b1728a55752.png)
