### PR TITLE
Fix like to dislike bar appearing misaligned

### DIFF
--- a/Extensions/combined/content-style.css
+++ b/Extensions/combined/content-style.css
@@ -42,7 +42,6 @@
 .ryd-tooltip-new-design {
   position: absolute;
   bottom: -10px;
-  left: -4px;
 }
 
 .ryd-tooltip-bar-container {

--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -14,8 +14,8 @@ function createRateBar(likes, dislikes) {
     let rateBar = document.getElementById("ryd-bar-container");
 
     const widthPx =
-      getLikeButton().clientWidth +
-      getDislikeButton().clientWidth +
+      parseFloat(window.getComputedStyle(getLikeButton()).width) +
+      parseFloat(window.getComputedStyle(getDislikeButton()).width) +
       (isRoundedDesign() ? 0 : 8);
 
     const widthPercent =


### PR DESCRIPTION
Fixes #809

---

I've found 2 more things which need to be fixed before this can be merged

- [ ] <img src="https://user-images.githubusercontent.com/81530705/204073283-4dda5996-bf69-426a-930c-c812dde870bc.png" width=260 />
 
- [ ] <img src="https://user-images.githubusercontent.com/81530705/204073302-2a0bfe83-bc2a-4a09-8a73-69553a03ed2e.png" width=260 />

Besides that, it also needs some testing on

- [ ] other browsers
- [ ] the old YT layout