### PR TITLE
fix: ratio bar not rendered on initial navigation towards video

### DIFF
--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -56,14 +56,21 @@ function createRateBar(likes, dislikes) {
           colorDislikeStyle = "; background-color: " + getColorFromTheme(false);
         }
 
-        (
-          document.getElementById(
-            isNewDesign() ? "top-level-buttons-computed" : "menu-container"
-          ) || document.querySelector("ytm-slim-video-action-bar-renderer")
-        ).insertAdjacentHTML(
+        const parent = document
+          .getElementsByTagName("ytd-watch-flexy")[0]
+          .querySelector("#primary ytd-watch-metadata");
+
+        const elementForInjection =
+          parent.querySelector(
+            isNewDesign() ? "#top-level-buttons-computed" : "#menu-container"
+          ) || parent.querySelector("ytm-slim-video-action-bar-renderer");
+
+        elementForInjection.insertAdjacentHTML(
           "beforeend",
           `
-              <div class="ryd-tooltip ryd-tooltip-${isNewDesign() ? "new" : "old"}-design" style="width: ${widthPx}px">
+              <div class="ryd-tooltip ryd-tooltip-${
+                isNewDesign() ? "new" : "old"
+              }-design" style="width: ${widthPx}px">
               <div class="ryd-tooltip-bar-container">
                 <div
                     id="ryd-bar-container"
@@ -79,7 +86,7 @@ function createRateBar(likes, dislikes) {
                 <!--css-build:shady-->${tooltipInnerHTML}
               </tp-yt-paper-tooltip>
               </div>
-      		`
+          `
         );
 
         if (isNewDesign()) {

--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -56,9 +56,9 @@ function createRateBar(likes, dislikes) {
           colorDislikeStyle = "; background-color: " + getColorFromTheme(false);
         }
 
-        const parent = document
-          .getElementsByTagName("ytd-watch-flexy")[0]
-          .querySelector("#primary ytd-watch-metadata");
+        const parent = document.querySelector(
+          "ytd-watch-flexy #primary ytd-watch-metadata"
+        );
 
         const elementForInjection =
           parent.querySelector(


### PR DESCRIPTION
The wrong element was being targeted. Apparently (maybe in a recent YouTube update), there was an additional custom element `ytd-browse` that was added; containing the home page content. This element was semantically placed **ABOVE** the `ytd-watch-flexy` custom element that contained `/watch` content. This was probably to ensure that the entire page (sidebars, etc.) wouldn't re-render on navigation changes. For now, this specifically targets the correct parent element.

Fixes #837 