### PR TITLE
Show dislikes again on new YT UI (01) & fix workflow faliure

### DIFF
--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -151,6 +151,17 @@ function setDislikes(dislikesCount) {
       return;
     }
     getDislikeTextContainer().innerText = dislikesCount;
+
+    try {
+      likeButton = document.querySelector("#segmented-like-button > ytd-toggle-button-renderer > yt-button-shape > button > div.cbox.yt-spec-button-shape-next--button-text-content > span")
+      dislikeButton = document.querySelector("#segmented-dislike-button > ytd-toggle-button-renderer > yt-button-shape > button")
+    }
+    finally {
+     dislikeButton.appendChild(likeButton.cloneNode(true))
+     document.querySelector('#segmented-dislike-button > ytd-toggle-button-renderer > yt-button-shape > button').classList.remove('yt-spec-button-shape-next--icon-button')
+    dislikeButton.lastChild.textContent = dislikesCount
+    }
+    
   } else {
     cLog("likes count disabled by creator");
     if (isMobile()) {

--- a/Website/nuxt.config.js
+++ b/Website/nuxt.config.js
@@ -5,7 +5,7 @@ import ru from "./_locales/ru";
 import cs from "./_locales/cs";
 import ja from "./_locales/ja";
 import fr from "./_locales/fr";
-import de from "./_locales/uk";
+import uk from "./_locales/uk";
 // import de from "./_locales/de";
 // ...
 export default {


### PR DESCRIPTION
# 1. Show dislikes again on one of the new YT UI layout

## After merging this PR
![New](https://user-images.githubusercontent.com/94835959/219364233-0b25bfc3-923e-4ca5-bd6f-2bbe82030911.png)

## Current main branch
![Old](https://user-images.githubusercontent.com/94835959/219364259-6b465670-309e-4bec-9f65-5c03d6eabfbb.png)

 ---

# 2. Fix failing weblint workflow

```
13  /home/runner/work/return-youtube-dislike/return-youtube-dislike/Website/nuxt.config.js
14     8:8   error  'de' is defined but never used  no-unused-vars
15    54:46  error  'uk' is not defined             no-undef
```

---

- The title has `(01)` as I expect similar PRs in future. 