### PR TITLE
Add Brazilian Portuguese translation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Read this in other languages: [русский](CONTRIBUTINGru.md), [Nederlands](CONTRIBUTINGnl.md), [Français](CONTRIBUTINGfr.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
+Read this in other languages: [Français](CONTRIBUTINGfr.md), [Nederlands](CONTRIBUTINGnl.md), [Português (Brasil)](CONTRIBUTINGpt-br.md), [русский](CONTRIBUTINGru.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
 
 
 # Welcome To Return YouTube Dislikes contributing guide

--- a/CONTRIBUTINGfr.md
+++ b/CONTRIBUTINGfr.md
@@ -1,5 +1,4 @@
-
-Lisez ceci dans d'autres langues : [English](CONTRIBUTING.md), [русский](CONTRIBUTINGru.md), Nederlands](CONTRIBUTINGnl.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
+Lisez ceci dans d'autres langues: [English](CONTRIBUTING.md), [Nederlands](CONTRIBUTINGnl.md), [Português (Brasil)](CONTRIBUTINGpt-br.md), [русский](CONTRIBUTINGru.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
 
 
 # Bienvenue dans le guide de contribution à Return YouTube Dislikes

--- a/CONTRIBUTINGnl.md
+++ b/CONTRIBUTINGnl.md
@@ -1,4 +1,4 @@
-Lees dit in andere talen: [English](CONTRIBUTINGen.md), [русский](CONTRIBUTINGru.md), [Français](CONTRIBUTINGfr.md), [Türkçe](CONTRIBUTINGtr.md)
+Lees dit in andere talen: [English](CONTRIBUTING.md), [Français](CONTRIBUTINGfr.md), [Português (Brasil)](CONTRIBUTINGpt-br.md), [русский](CONTRIBUTINGru.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
 
 # Welkom bij de YouTube Dislikes bijdragengids
 

--- a/CONTRIBUTINGpt-br.md
+++ b/CONTRIBUTINGpt-br.md
@@ -1,0 +1,68 @@
+Leia em outros idiomas: [русский](CONTRIBUTINGru.md), [Nederlands](CONTRIBUTINGnl.md), [Français](CONTRIBUTINGfr.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
+
+
+# Bem-vindo ao guia de contribuição do Return YouTube Dislikes
+
+Obrigado por investir seu tempo contribuindo para nosso projeto! Todas as suas alterações serão refletidas na próxima versão da extensão (ou do [site](https://www.returnyoutubedislike.com/)).
+
+## Começando
+
+Por favor, use o Prettier com as configurações padrão para formatar.
+
+#### Pré-requisitos
+
+Você precisa ter o node e npm instalados para criar a versão empacotada da fonte.
+
+Versões usadas durante a configuração:
+
+- node: 12.18.4
+- npm: 6.14.6
+
+Para criar o `bundled-content-script.js`, que contém a maior parte da lógica do negócio desta extensão, você precisa instalar todas as dependências primeiro.
+
+1.  Vá para a raiz do repositório e execute:
+
+```
+npm install
+```
+
+2.  Execute o seguinte comando para criar `bundled-content-script.js`, que é usado em `manifest.json`.
+
+```
+npm start // para criar o(s) arquivo(s) de construção e iniciar um observador de arquivos que recarrega na gravação
+
+// ou
+
+npm run build // para criar o(s) arquivo(s) de construção uma vez
+```
+
+Parabéns, agora você está pronto para desenvolver!
+
+Se você é novo no desenvolvimento de extensões para o Chrome ou precisa de ajuda extra, consulte [este tutorial do YouTube](https://www.youtube.com/watch?v=mdOj6HYE3_0).
+
+### Issues
+
+#### Abrindo uma nova issue
+
+Se você tiver algum problema com a extensão, pesquise para verificar se a issue ainda não foi relatada. Se não foi, abra uma issue, usar o formulário de issue é altamente recomendado, mas não obrigatório.
+
+#### Resolvendo uma issue
+
+Se você encontrou uma issue que acredita ser capaz de resolver, não seja tímido. Abra um PR com a correção e certifique-se de mencionar a issue que está corrigindo.
+
+### Solicitação de recurso
+
+#### Abrindo uma nova solitação de recurso
+
+Se você tem uma ideia para a extensão, sinta-se à vontade para abrir uma solicitação de recurso, mas pesquise antes para ter certeza de que o recurso ainda não foi sugerido. Usar o formulário de recurso é altamente recomendado, mas não obrigatório.
+
+#### Implementando uma solicitação de recurso
+
+Se você encontrou um recurso que acredita ser capaz de implementar, não seja tímido. Abra um PR com a correção e certifique-se de mencionar o recurso que está implementando.
+
+### Quais PRs aceitamos?
+
+- Correções de problemas.
+- Implementação de recursos.
+- Correção de erros de digitação ou palavras melhores e mais fáceis de usar.
+- Contribuições para o site.

--- a/CONTRIBUTINGpt-br.md
+++ b/CONTRIBUTINGpt-br.md
@@ -1,4 +1,4 @@
-Leia em outros idiomas: [русский](CONTRIBUTINGru.md), [Nederlands](CONTRIBUTINGnl.md), [Français](CONTRIBUTINGfr.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
+Leia em outros idiomas: [English](CONTRIBUTING.md), [Français](CONTRIBUTINGfr.md), [Nederlands](CONTRIBUTINGnl.md), [русский](CONTRIBUTINGru.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
 
 
 # Bem-vindo ao guia de contribuição do Return YouTube Dislikes

--- a/CONTRIBUTINGru.md
+++ b/CONTRIBUTINGru.md
@@ -1,4 +1,4 @@
-Прочитать на других языках: [English](CONTRIBUTING.md), [Nederlands](CONTRIBUTINGnl.md), [Français](CONTRIBUTINGfr.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
+Прочитать на других языках: [English](CONTRIBUTING.md), [Français](CONTRIBUTINGfr.md), [Nederlands](CONTRIBUTINGnl.md), [Português (Brasil)](CONTRIBUTINGpt-br.md), [Türkçe](CONTRIBUTINGtr.md), [українська](CONTRIBUTINGuk.md)
 
 
 # Добро пожаловать в руководство по внесению вклада Return YouTube Dislikes

--- a/CONTRIBUTINGtr.md
+++ b/CONTRIBUTINGtr.md
@@ -1,4 +1,4 @@
-Bunu diğer dillerde okuyun: [English](CONTRIBUTING.md), [русский](CONTRIBUTINGru.md), [Nederlands](CONTRIBUTINGnl.md), [Français](CONTRIBUTINGfr.md), [українська](CONTRIBUTINGuk.md)
+Bunu diğer dillerde okuyun: [English](CONTRIBUTING.md), [Français](CONTRIBUTINGfr.md), [Nederlands](CONTRIBUTINGnl.md), [Português (Brasil)](CONTRIBUTINGpt-br.md), [русский](CONTRIBUTINGru.md), [українська](CONTRIBUTINGuk.md)
 
 # "YouTube Dislike Sayısını Geri Getir"in katkı kılavuzuna Hoş Geldiniz
 

--- a/CONTRIBUTINGuk.md
+++ b/CONTRIBUTINGuk.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](CONTRIBUTING.md), [русский](CONTRIBUTINGru.md), [Français](CONTRIBUTINGfr.md), [Türkçe](CONTRIBUTINGtr.md)
+Read this in other languages: [English](CONTRIBUTING.md), [Français](CONTRIBUTINGfr.md), [Nederlands](CONTRIBUTINGnl.md), [Português (Brasil)](CONTRIBUTINGpt-br.md), [русский](CONTRIBUTINGru.md), [Türkçe](CONTRIBUTINGtr.md)
 
 # Вітаємо у посібнику внеску в Return YouTube Dislikes
 

--- a/Docs/FAQ.md
+++ b/Docs/FAQ.md
@@ -1,4 +1,4 @@
-Read this in other languages: [русский](FAQru.md), [Français](FAQfr.md),  [Nederlands](FAQnl.md),[Türkçe](FAQtr.md), [українська](FAQuk.md)
+Read this in other languages: [Français](FAQfr.md), [Nederlands](FAQnl.md), [Português (Brasil)](FAQpt-br.md), [русский](FAQru.md), [Türkçe](FAQtr.md), [українська](FAQuk.md)
 
 
 # Frequently Asked Questions

--- a/Docs/FAQ.md
+++ b/Docs/FAQ.md
@@ -51,7 +51,7 @@ RYD uses the votes from its users to extrapolate the dislike count.
 
 This in video form
 
-[![IReturn YouTube Dislike Explained](https://yt-embed.herokuapp.com/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
+[![Return YouTube Dislike Explained](https://yt-embed.live/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
 
 ---
 

--- a/Docs/FAQfr.md
+++ b/Docs/FAQfr.md
@@ -1,4 +1,4 @@
-Lisez ceci dans d'autres langues : [English](FAQ.md), [русский](FAQru.md), [Nederlands](FAQnl.md), [Türkçe](FAQtr.md), [українська](FAQuk.md)
+Lisez ceci dans d'autres langues: [English](FAQ.md), [Nederlands](FAQnl.md), [Português (Brasil)](FAQpt-br.md), [русский](FAQru.md), [Türkçe](FAQtr.md), [українська](FAQuk.md)
 
 
 # Foire Aux Questions

--- a/Docs/FAQnl.md
+++ b/Docs/FAQnl.md
@@ -50,7 +50,7 @@ RYD gebruikt de stemmen van zijn gebruikers om het aantal dislikes te extrapoler
 
 Dit in videovorm
 
-[![IReturn YouTube Dislike Uitgelegd (Engels)](https://yt-embed.herokuapp.com/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
+[![Return YouTube Dislike Uitgelegd (Engels)](https://yt-embed.live/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
 
 ---
 

--- a/Docs/FAQnl.md
+++ b/Docs/FAQnl.md
@@ -1,4 +1,4 @@
-Lees dit in andere talen: [Engels](FAQ.md), [русский](FAQru.md), [Français](FAQfr.md), [Türkçe](FAQtr.md)
+Lees dit in andere talen: [English](FAQ.md), [Français](FAQfr.md), [Português (Brasil)](FAQpt-br.md), [русский](FAQru.md), [Türkçe](FAQtr.md), [українська](FAQuk.md)
 
 # Veel Gestelde Vragen
 

--- a/Docs/FAQpt-br.md
+++ b/Docs/FAQpt-br.md
@@ -1,0 +1,62 @@
+Leia isso em outros idiomas: [русский](FAQru.md), [Français](FAQfr.md),  [Nederlands](FAQnl.md),[Türkçe](FAQtr.md), [українська](FAQuk.md)
+
+
+# Perguntas Frequentes
+
+## Antes de fazer uma pergunta no GitHub ou no Discord, consulte isto.
+
+<br>
+
+### **1. De onde vêm os dados dessa extensão?**
+
+Uma combinação de APIs do Google e dados coletados por raspagem.
+
+Nós salvamos todos os dados disponíveis em nosso banco de dados para que ficassem disponíveis após o Google desativar a contagem de dislikes em sua API.
+
+<br>
+
+### **2. A contagem de dislikes do vídeo não atualiza**
+
+Atualmente, as dislikes dos vídeos são armazenados em cache e não são atualizadas com muita frequência. Uma vez a cada 2-3 dias, não mais frequentemente que isso.
+
+Sim, não é ideal, mas é o que é. Estamos trabalhando para melhorar a frequência de atualização desses dados.
+
+<br>
+
+### **3. Como isso funciona?**
+
+A extensão coleta o ID do vídeo que você está assistindo, busca os dislikes (e outros campos, como visualizações, curtidas etc.) usando nossa API. Se for a primeira vez que o vídeo é buscado por nossa API, ela usará a API do YouTube para obter os dados, em seguida, armazena os dados em um banco de dados para fins de cache (armazenado em cache por cerca de 2-3 dias) e arquivamento, e os retorna para você. A extensão então exibe os dislikes para você.
+
+<br>
+
+### **4. O que acontecerá quando a API do YouTube parar de retornar a contagem de dislikes?**
+
+O backend passará a usar uma combinação de estatísticas de dislikes arquivadas, estimativas extrapoladas dos dados dos usuários da extensão e estimativas baseadas nas proporções de visualizações/likes para vídeos cujos dislikes não foram arquivadas e para arquivos de dislikes desatualizados.
+
+<br>
+
+### **5. Como a contagem de dislikes é calculada?**
+
+O RYD usa os votos de seus usuários para extrapolar a contagem de dislikes.
+
+- Se o vídeo foi carregado após o desligamento da API:
+
+  $$ \textup{Contagem de Dislikes do RYD} = \left( \frac{\textup{Contagem de Dislikes dos Usuários do RYD}}{\textup{Contagem de Likes dos Usuários do RYD}} \right) \times \textup{Contagem de Likes Pública} $$
+
+- Se o banco de dados do RYD de alguma forma tiver a contagem real de likes e dislikes (fornecida pelo carregador do vídeo ou do arquivo), a contagem de dislikes será calculada com base em ambos - os votos dos usuários e o valor arquivado. O valor arquivado terá menos influência na contagem final conforme envelhece.
+
+<br>
+
+---
+
+Isso em forma de vídeo
+
+[![Return YouTube Dislike Explained](https://yt-embed.live/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
+
+---
+
+<br>
+
+## Eu tenho preocupações com segurança / privacidade
+
+Veja [esta página](SECURITY-FAQpt-br.md) para mais informações.

--- a/Docs/FAQpt-br.md
+++ b/Docs/FAQpt-br.md
@@ -1,4 +1,4 @@
-Leia isso em outros idiomas: [русский](FAQru.md), [Français](FAQfr.md),  [Nederlands](FAQnl.md),[Türkçe](FAQtr.md), [українська](FAQuk.md)
+Leia isso em outros idiomas: [English](FAQ.md), [Français](FAQfr.md), [Nederlands](FAQnl.md), [русский](FAQru.md), [Türkçe](FAQtr.md), [українська](FAQuk.md)
 
 
 # Perguntas Frequentes

--- a/Docs/FAQru.md
+++ b/Docs/FAQru.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](FAQ.md),  [Nederlands](FAQnl.md), Français](FAQfr.md), [Türkçe](FAQtr.md), [українська](FAQuk.md)
+Read this in other languages: [English](FAQ.md), [Français](FAQfr.md), [Nederlands](FAQnl.md), [Português (Brasil)](FAQpt-br.md), [Türkçe](FAQtr.md), [українська](FAQuk.md)
 
 
 # Часто задаваемые вопросы

--- a/Docs/FAQtr.md
+++ b/Docs/FAQtr.md
@@ -51,7 +51,7 @@ YDS, dislike sayısını tahmin etmek için kullanıcılarının oylarını kull
 
 Bu video şeklinde
 
-[![IReturn YouTube Dislike Explained](https://yt-embed.herokuapp.com/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
+[![Return YouTube Dislike Explained](https://yt-embed.live/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
 
 ---
 

--- a/Docs/FAQtr.md
+++ b/Docs/FAQtr.md
@@ -1,4 +1,4 @@
-Bunu diğer dillerde okuyun: [English](FAQ.md), [русский](FAQru.md), ), [Nederlands](FAQnl.md), [Français](FAQfr.md), [українська](FAQuk.md)
+Bunu diğer dillerde okuyun: [English](FAQ.md), [Français](FAQfr.md), [Nederlands](FAQnl.md), [Português (Brasil)](FAQpt-br.md), [русский](FAQru.md), [українська](FAQuk.md)
 
 
 # Sıkça Sorulan Sorular

--- a/Docs/FAQuk.md
+++ b/Docs/FAQuk.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](FAQ.md), [русский](FAQru.md), [Français](FAQfr.md), [Türkçe](FAQtr.md)
+Read this in other languages: [English](FAQ.md), [Français](FAQfr.md), [Nederlands](FAQnl.md), [Português (Brasil)](FAQpt-br.md), [русский](FAQru.md), [Türkçe](FAQtr.md)
 
 # Часті питання
 

--- a/Docs/FAQuk.md
+++ b/Docs/FAQuk.md
@@ -50,7 +50,7 @@ RYD використовує відмітки своїх користувачі�
 
 Це все, але у відео форматі
 
-[![IReturn YouTube Dislike Explained](https://yt-embed.herokuapp.com/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
+[![Return YouTube Dislike Explained](https://yt-embed.live/embed?v=GSmmtv-0yYQ)](https://www.youtube.com/watch?v=GSmmtv-0yYQ)
 
 ---
 

--- a/Docs/SECURITY-FAQ.md
+++ b/Docs/SECURITY-FAQ.md
@@ -1,4 +1,4 @@
-Read this in other languages: [русский](SECURITY-FAQru.md), [Nederlands](SECURITY_FAQnl.md), [Français](SECURITY-FAQfr.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
+Read this in other languages: [Français](SECURITY-FAQfr.md), [Nederlands](SECURITY_FAQnl.md), [Português (Brasil)](SECURITY-FAQpt-br.md), [русский](SECURITY-FAQru.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
 
 
 # Security

--- a/Docs/SECURITY-FAQfr.md
+++ b/Docs/SECURITY-FAQfr.md
@@ -1,4 +1,4 @@
-Lisez ceci dans d'autres langues : [English](SECURITY-FAQ.md), [русский](SECURITY-FAQru.md), Nederlands](SECURITY_FAQnl.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
+Lisez ceci dans d'autres langues: [English](SECURITY-FAQ.md), [Nederlands](SECURITY_FAQnl.md), [Português (Brasil)](SECURITY-FAQpt-br.md), [русский](SECURITY-FAQru.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
 
 # Sécurité
 

--- a/Docs/SECURITY-FAQnl.md
+++ b/Docs/SECURITY-FAQnl.md
@@ -1,4 +1,4 @@
-Lees dit in andere talen: [English](SECURITY_FAQ.md), [русский](SECURITY-FAQru.md), [Français](SECURITY-FAQfr.md), [Türkçe](SECURITY-FAQtr.md)
+Lees dit in andere talen: [English](SECURITY-FAQ.md), [Français](SECURITY-FAQfr.md), [Português (Brasil)](SECURITY-FAQpt-br.md), [русский](SECURITY-FAQru.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
 
 # Veiligheid
 

--- a/Docs/SECURITY-FAQpt-br.md
+++ b/Docs/SECURITY-FAQpt-br.md
@@ -1,0 +1,32 @@
+Leia isso em outros idiomas: [русский](SECURITY-FAQru.md), [Nederlands](SECURITY_FAQnl.md), [Français](SECURITY-FAQfr.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
+
+
+# Segurança
+
+### Vocês estão rastreando meu histórico de visualização?
+
+Não. O código da extensão é público e você pode vê-lo por si mesmo. A única informação sendo enviada é o ID do vídeo, que é necessário para buscar a contagem de dislikes nos vídeos. Não há cabeçalhos adicionais sendo enviados. Sobre a camada de comunicação, seu IP público será exposto ao servidor, assim como a hora em que a solicitação foi feita. No entanto, nada disso está identificando você de forma única. Supondo um ambiente de zero confiança, o melhor que poderíamos obter é um IP dinâmico. Que hoje é seu, amanhã é do seu vizinho. Se você está realmente preocupado com o rastreamento do seu IP, provavelmente já usa uma VPN.
+
+### Vocês podem me identificar de forma única se eu der um dislike?
+
+Sim. Quando você dá dislike em um vídeo, criamos um ID único gerado aleatoriamente para você que não está vinculado à sua conta do Google. Isso é feito para evitar bots. Mas não há maneira de vincular esse ID aleatório a você ou à sua conta pessoal do YouTube.
+
+### Que informações vocês têm, exatamente?
+
+Apenas o ID do vídeo. Não seus comentários, não seu nome de usuário, não com quem você compartilhou o vídeo, não qualquer metadado adicional. Nada. Apenas o ID do vídeo.
+
+### Como meu IP é armazenado?
+
+O backend mantém os endereços IP sem hash apenas na memória volátil (RAM). Esses endereços não são armazenados em um disco rígido e, portanto, não são registrados. Fazemos os hashs dos endereços IP e isso que é armazenado. Isso é feito para evitar a vandalização do banco de dados.
+
+### Ouvi uma discussão sobre OAuth e acesso à minha conta do YouTube!
+
+Essa funcionalidade será opcional e completamente voluntária. Se você é um criador de conteúdo do YouTube e deseja compartilhar suas estatísticas de dislikes conosco, poderá fazê-lo. A maneira como o [OAuth](https://pt.wikipedia.org/wiki/OAuth#:~:text=mas%2C%20sem%20expor%20credenciais%20de%20autentica%C3%A7%C3%A3o%2C%20como%20senhas.) foi estruturado é na verdade muito segura. Você pode revogar o acesso à sua conta a qualquer momento e pode nos dar permissões muito específicas. Não solicitaremos nenhuma permissão que não seja necessária. Apenas solicitaremos permissões para visualizar as estatísticas do seu vídeo.
+
+### Como posso confiar na contagem de dislikes?
+
+Implementamos medidas para evitar ataques de bots e continuaremos trabalhando para melhorar a eficácia do sistema de prevenção de bots: isso nos ajudará a manter a contagem de dislikes como um bom representatativo da contagem real. Claro que nunca será 100% preciso, então cabe a você decidir se confia na contagem ou não.
+
+### Por que vocês não compartilham o código do backend?
+
+Compartilharemos em algum momento - mas realmente não há motivo real para compartilhá-lo agora. Isso dá uma falsa sensação de segurança - porque em um sistema de zero confiança, poderíamos muito bem divulgar uma versão, mas implantar outra. Há muitas razões para manter o código oculto, especialmente como lidamos com spam. Esconder/obscurecer o código de tratamento de spam é uma prática bastante padrão.

--- a/Docs/SECURITY-FAQpt-br.md
+++ b/Docs/SECURITY-FAQpt-br.md
@@ -1,4 +1,4 @@
-Leia isso em outros idiomas: [русский](SECURITY-FAQru.md), [Nederlands](SECURITY_FAQnl.md), [Français](SECURITY-FAQfr.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
+Leia isso em outros idiomas: [English](SECURITY-FAQ.md), [Français](SECURITY-FAQfr.md), [Nederlands](SECURITY_FAQnl.md), [русский](SECURITY-FAQru.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
 
 
 # Segurança

--- a/Docs/SECURITY-FAQru.md
+++ b/Docs/SECURITY-FAQru.md
@@ -1,4 +1,4 @@
-Прочитать на других языках: [English](SECURITY-FAQ.md), [Nederlands](SECURITY_FAQnl.md), [Français](SECURITY-FAQfr.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
+Прочитать на других языках: [English](SECURITY-FAQ.md), [Français](SECURITY-FAQfr.md), [Nederlands](SECURITY_FAQnl.md), [Português (Brasil)](SECURITY-FAQpt-br.md), [Türkçe](SECURITY-FAQtr.md), [українська](SECURITY-FAQuk.md)
 
 # Безопасность
 

--- a/Docs/SECURITY-FAQtr.md
+++ b/Docs/SECURITY-FAQtr.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](SECURITY-FAQ.md), [русский](SECURITY-FAQru.md),  [Nederlands](SECURITY_FAQnl.md), [Français](SECURITY-FAQfr.md), [українська](SECURITY-FAQuk.md)
+Read this in other languages: [English](SECURITY-FAQ.md), [Français](SECURITY-FAQfr.md), [Nederlands](SECURITY_FAQnl.md), [Português (Brasil)](SECURITY-FAQpt-br.md), [русский](SECURITY-FAQru.md), [українська](SECURITY-FAQuk.md)
 
 # Güvenlik
 

--- a/Docs/SECURITY-FAQuk.md
+++ b/Docs/SECURITY-FAQuk.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](SECURITY-FAQ.md), [русский](SECURITY-FAQru.md), [Français](SECURITY-FAQfr.md), [Türkçe](SECURITY-FAQtr.md)
+Read this in other languages: [English](SECURITY-FAQ.md), [Français](SECURITY-FAQfr.md), [Nederlands](SECURITY_FAQnl.md), [Português (Brasil)](SECURITY-FAQpt-br.md), [русский](SECURITY-FAQru.md), [Türkçe](SECURITY-FAQtr.md)
 
 # Безпека
 

--- a/Docs/readme.md
+++ b/Docs/readme.md
@@ -1,4 +1,4 @@
-Read this in other languages: [Nederlands](readmenl.md), [Français](readmefr.md), [Türkçe](READMEtr.md)
+Read this in other languages: [Français](readmefr.md), [Nederlands](readmenl.md), [Português (Brasil)](readmept-br.md), [Türkçe](READMEtr.md)
 
 **Contents**
 

--- a/Docs/readmefr.md
+++ b/Docs/readmefr.md
@@ -1,4 +1,4 @@
-Lisez ceci dans d'autres langues : [English](readme.md), [Nederlands](readmenl.md), [Türkçe](READMEtr.md)
+Lisez ceci dans d'autres langues: [English](readme.md), [Nederlands](readmenl.md), [Português (Brasil)](readmept-br.md), [Türkçe](READMEtr.md)
 
 **Contenu**
 

--- a/Docs/readmenl.md
+++ b/Docs/readmenl.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](readme.md), [Français](readmefr.md), [Türkçe](READMEtr.md)
+Read this in other languages: [English](readme.md), [Français](readmefr.md), [Português (Brasil)](readmept-br.md), [Türkçe](READMEtr.md)
 
 **Inhoud**
 

--- a/Docs/readmept-br.md
+++ b/Docs/readmept-br.md
@@ -1,4 +1,4 @@
-Leia em outros idiomas: [Nederlands](readmenl.md), [Français](readmefr.md), [Türkçe](READMEtr.md)
+Leia em outros idiomas: [English](readme.md), [Français](readmefr.md), [Nederlands](readmenl.md), [Türkçe](READMEtr.md)
 
 **Conteúdos**
 

--- a/Docs/readmept-br.md
+++ b/Docs/readmept-br.md
@@ -1,0 +1,39 @@
+Leia em outros idiomas: [Nederlands](readmenl.md), [Français](readmefr.md), [Türkçe](READMEtr.md)
+
+**Conteúdos**
+
+- [Guias](#guias)
+- [FAQs](#faqs)
+<!-- - [FAQs](#faqs)
+- [Outras Listas](#outras-listas) -->
+
+<br>
+
+## Guias
+
+- [Baixando, Instalando & Usando](https://github.com/Anarios/return-youtube-dislike/wiki/Downloading,-Installing-&-Using)
+- [Resolvendo Problemas](https://github.com/Anarios/return-youtube-dislike/wiki/Troubleshooting-Guide)
+<!-- - [FAQ](FAQpt-br.md)
+- [Quando & Como Reportar Bugs](Guide__Bug_Reportingpt-br.md)
+- [Contribuindo](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGpt-br.md) -->
+<!-- - [Como atualizar a wiki](/) -->
+
+<br>
+
+## FAQs
+
+- [Geral](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQpt-br.md)
+- [Segurança](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/SECURITY-FAQpt-br.md)
+
+<!-- - [Privacidade](FAQ_Privacypt-br.md)
+- [Técnico](FAQ_Technicalpt-br.md)
+- [Criadores](FAQ_Creatorspt-br.md)
+
+<br>
+
+## Outras Listas
+
+- [Problemas Comuns](Common_Problemspt-br.md)
+- [Perguntas Repetidas](Repeated_Questionspt-br.md)
+- [Solicitações de Recursos Repetidas](Repeated_Feature_requestspt-br.md)
+- [Issues Repetidas](Repeated_Issuespt-br.md)

--- a/Docs/readmetr.md
+++ b/Docs/readmetr.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](readme.md), [Nederlands](readmenl.md), [Français](readmefr.md)
+Read this in other languages: [English](readme.md), [Français](readmefr.md), [Nederlands](readmenl.md), [Português (Brasil)](readmept-br.md)
 
 **İçerikler**
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [русский](READMEru.md), [Español](READMEes.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md)
+Read this in other languages: [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [日本語](READMEja.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [русский](READMEru.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
 
 
 # Return YouTube Dislike

--- a/READMEde.md
+++ b/READMEde.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Lesen sie dies in anderen Sprachen: [English](README.md), [Español](READMEes.md), [русский](READMEru.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
+Lesen sie dies in anderen Sprachen: [English](README.md), [Español](READMEes.md), [Français](READMEfr.md), [日本語](READMEja.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [русский](READMEru.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
 
 # Return YouTube Dislike
 

--- a/READMEes.md
+++ b/READMEes.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Leer en otros idiomas: [English](README.md), [русский](READMEru.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md)
+Leer en otros idiomas: [English](README.md), [Deutsch](READMEde.md), [Français](READMEfr.md), [日本語](READMEja.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [русский](READMEru.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
 
 
 # Return YouTube Dislike

--- a/READMEfr.md
+++ b/READMEfr.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](LICENSE)
 
-Lisez ceci dans d'autres langues : [English](README.md), [русский](READMEru.md),  [Español](READMEes.md), [Nederlands](READMEnl.md),[日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md)
+Lisez ceci dans d'autres langues: [English](README.md), [Deutsch](READMEde.md), [Español](READMEes.md), [日本語](READMEja.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [русский](READMEru.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
 
 
 # Return YouTube Dislike

--- a/READMEja.md
+++ b/READMEja.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-別の言語: [English](README.md), [русский](READMEru.md), [Español](READMEes.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md)
+別の言語: [English](README.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [русский](READMEru.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
 
 
 # Return YouTube Dislike

--- a/READMEnl.md
+++ b/READMEnl.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Lees dit in andere talen: [English](README.md), [Español](READMEes.md), [русский](READMEru.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md)
+Lees dit in andere talen: [English](README.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [日本語](READMEja.md), [Português (Brasil)](READMEpt-br.md), [русский](READMEru.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
 
 # Return YouTube Dislike
 

--- a/READMEpt-br.md
+++ b/READMEpt-br.md
@@ -1,0 +1,95 @@
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/stars/gebbhagfogifgggkldgodflihgfeippi?label=Chrome%20Rating&style=flat&logo=google)](https://chrome.google.com/webstore/detail/youtube-dislike-button/gebbhagfogifgggkldgodflihgfeippi/)
+[![Chrome Web Store Users](https://img.shields.io/chrome-web-store/users/gebbhagfogifgggkldgodflihgfeippi?label=Chrome%20Users&style=flat&logo=google)](https://chrome.google.com/webstore/detail/youtube-dislike-button/gebbhagfogifgggkldgodflihgfeippi/)
+[![Mozilla rating](https://img.shields.io/amo/stars/return-youtube-dislikes?label=Firefox%20Rating&style=flat&logo=firefox)](https://addons.mozilla.org/en-US/firefox/addon/return-youtube-dislikes/)
+[![Mozilla downloads](https://img.shields.io/amo/users/return-youtube-dislikes?label=Firefox%20Users&style=flat&logo=firefox)](https://addons.mozilla.org/en-US/firefox/addon/return-youtube-dislikes/)
+[![Commit rate](https://img.shields.io/github/commit-activity/m/Anarios/return-youtube-dislike?label=Commits&style=flat)](https://github.com/Anarios/return-youtube-dislike/commits/main)
+[![Issues](https://img.shields.io/github/issues/Anarios/return-youtube-dislike?style=flat&label=Issues)](https://github.com/Anarios/return-youtube-dislike/issues)
+[![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
+[![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
+
+Leia em outros idiomas: [русский](READMEru.md), [Español](READMEes.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md)
+
+
+# Return YouTube Dislike
+
+<p align="center">
+    <b>Return YouTube Dislike é uma extensão de código aberto que retorna a contagem de dislikes do YouTube.</b><br>
+    Disponível para Chrome e Firefox como Extensão da Web.<br>
+    Também disponível para outros navegadores como JS Userscript.<br><br>
+    <img width="400px" src="https://user-images.githubusercontent.com/18729296/141743755-2be73297-250e-4cd1-ac93-8978c5a39d10.png"/>
+</p>
+
+## A História
+
+Em 10 de novembro de 2021, o Google [anunciou](https://blog.youtube/news-and-events/update-to-youtube/) que a contagem de dislikes do YouTube seria removida.
+
+Além disso, o campo `dislike` na API do YouTube foi [removido](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts) em 13 de dezembro de 2021, removendo qualquer capacidade de julgar a qualidade do conteúdo antes de assistí-lo.
+
+## O que ela faz
+
+Com a remoção das estatísticas do dislikes da API do YouTube, nosso backend passou a usar uma combinação de estatísticas de dislikes raspadas e estimativas extrapoladas a partir dos dados dos usuários da extensão.
+
+[FAQ](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQpt-br.md)
+
+## Por que isso importa
+
+Você pode saber mais no nosso site em: [returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
+
+## Documentação da API
+
+O uso de terceiros desta API aberta é permitido com as seguintes restrições:
+
+- **Atribuição**: Este projeto deve ser claramente atribuído com um link para [returnyoutubedislike.com](https://returnyoutubedislike.com/).
+- **Limitação de taxa**: Existem limites de taxa por cliente de 100 por minuto e 10.000 por dia. Isso retornará um código de status _429_, indicando que sua aplicação deve diminuir a velocidade.
+
+A API é acessível no seguinte URL base:  
+[https://returnyoutubedislikeapi.com](https://returnyoutubedislikeapi.com/)
+
+Lista de endpoints disponíveis está disponível aqui:  
+[https://returnyoutubedislikeapi.com/swagger/index.html](https://returnyoutubedislikeapi.com/swagger/index.html)
+
+### Obter votos
+
+Exemplo para obter votos de um determinado ID de vídeo do YouTube:  
+`/votes?videoId=kxOuG8jMIgI`
+
+```json
+{
+  "id": "kxOuG8jMIgI",
+  "dateCreated": "2021-12-20T12:25:54.418014Z",
+  "likes": 27326,
+  "dislikes": 498153,
+  "rating": 1.212014408444885,
+  "viewCount": 3149885,
+  "deleted": false
+}
+```
+
+Um ID do YouTube inexistente retornará o código de status _404_ "Not Found".  
+Um ID do YouTube com formato incorreto retornará _400_ "Bad Request".
+
+<!---
+## Documentação da API
+
+ Você pode ver toda a documentação em nosso site.
+[https://returnyoutubedislike.com/documentation/](https://returnyoutubedislike.com/documentation/) -->
+
+## Contribuindo
+
+Por favor, leia o [guia de contribuição](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGpt-br.md).
+
+## Apoie este projeto!
+
+Você pode apoiar este projeto nos doando no link abaixo:
+
+[Doar](https://returnyoutubedislike.com/donate)
+
+## Patrocinadores
+
+[Piepacker](https://piepacker.com)
+
+[Seed4.Me VPN](https://www.seed4.me/users/register?gift=ReturnYoutubeDislike)
+
+[PocketTube](https://yousub.info/?utm_source=returnyoutubedislike)
+
+[Torne-se nosso patrocinador](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEpt-br.md
+++ b/READMEpt-br.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Leia em outros idiomas: [русский](READMEru.md), [Español](READMEes.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md)
+Leia em outros idiomas: [English](README.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [日本語](READMEja.md), [Nederlands](READMEnl.md), [русский](READMEru.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
 
 
 # Return YouTube Dislike

--- a/READMEru.md
+++ b/READMEru.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Прочитать на других языках: [English](README.md), [Español](READMEes.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md)
+Прочитать на других языках: [English](README.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [日本語](READMEja.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [Türkçe](READMEtr.md), [українська](READMEuk.md)
 
 
 # Return YouTube Dislike

--- a/READMEtr.md
+++ b/READMEtr.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![Lisans](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Bunu diğer dillerde okuyun: [English](README.md), [русский](READMEru.md), [Español](READMEes.md), [Français](READMEfr.md), [Nederlands](READMEnl.md), [日本語](READMEja.md), [українська](READMEuk.md), [Deutsch](READMEde.md)
+Bunu diğer dillerde okuyun: [English](README.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [日本語](READMEja.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [русский](READMEru.md), [українська](READMEuk.md)
 
 
 # YouTube Dislike Sayısını Geri Getir

--- a/READMEuk.md
+++ b/READMEuk.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [Español](READMEes.md), [русский](READMEru.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [Deutsch](READMEde.md)
+Read this in other languages: [English](README.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [日本語](READMEja.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [русский](READMEru.md), [Türkçe](READMEtr.md)
 
 # Return YouTube Dislike
 

--- a/Website/README.md
+++ b/Website/README.md
@@ -1,4 +1,4 @@
-Read this in other languages: [Nederlands](READMEnl.md), [Türkçe](READMEtr.md)
+Read this in other languages: [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [Türkçe](READMEtr.md)
 
 # return-youtube-dislike-site
 

--- a/Website/READMEnl.md
+++ b/Website/READMEnl.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](README.md), [Türkçe](READMEtr.md)
+Read this in other languages: [English](README.md), [Português (Brasil)](READMEpt-br.md), [Türkçe](READMEtr.md)
 
 # return-youtube-dislike-site
 

--- a/Website/READMEpt-br.md
+++ b/Website/READMEpt-br.md
@@ -1,4 +1,4 @@
-Leia em outros idiomas: [Nederlands](READMEnl.md), [Türkçe](READMEtr.md)
+Leia em outros idiomas: [English](README.md), [Nederlands](READMEnl.md), [Türkçe](READMEtr.md)
 
 # return-youtube-dislike-site
 

--- a/Website/READMEpt-br.md
+++ b/Website/READMEpt-br.md
@@ -1,0 +1,89 @@
+Leia em outros idiomas: [Nederlands](READMEnl.md), [Türkçe](READMEtr.md)
+
+# return-youtube-dislike-site
+
+## Configuração de Build
+
+```bash
+# instalar dependências
+$ npm install
+
+# executar com hot reload em localhost:3000
+$ npm run dev
+
+# verificar seu código com ESLint
+$ npm run lint
+
+# gerar build para produção e lançar o servidor
+$ npm run build
+$ npm run start
+
+# gerar projeto estático
+$ npm run generate
+```
+
+Para uma explicação detalhada sobre como as coisas funcionam, confira a [documentação](https://nuxtjs.org/).
+
+## Configuração recomendada para o VSCode
+
+- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) `ext install dbaeumer.vscode-eslint`
+- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) `ext install esbenp.prettier-vscode`
+- [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur)
+
+> `Ctrl(Cmd)` + `Shift` + `P` > Abrir Configurações (JSON)
+
+```
+"editor.formatOnSave": true,
+"editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+}
+"vetur.validation.template": false,
+```
+
+## Diretórios Especiais
+
+Você pode criar os seguintes diretórios extras, alguns dos quais têm comportamentos especiais. Apenas `pages` é obrigatório; você pode excluí-los se não quiser usar sua funcionalidade.
+
+### `assets`
+
+O diretório de assets contém seus assets não compilados, como arquivos Stylus ou Sass, imagens ou fontes.
+
+Mais informações sobre o uso deste diretório na [documentação](https://nuxtjs.org/docs/2.x/directory-structure/assets).
+
+### `components`
+
+O diretório de componentes contém seus componentes Vue.js. Os componentes compõem as diferentes partes da sua página e podem ser reutilizados e importados em suas páginas, layouts e até mesmo outros componentes.
+
+Mais informações sobre o uso deste diretório na [documentação](https://nuxtjs.org/docs/2.x/directory-structure/components).
+
+### `layouts`
+
+Os layouts são de grande ajuda quando você deseja mudar a aparência e sensação do seu aplicativo Nuxt, seja incluindo uma barra lateral ou tendo layouts distintos para dispositivos móveis e desktop.
+
+Mais informações sobre o uso deste diretório na [documentação](https://nuxtjs.org/docs/2.x/directory-structure/layouts).
+
+### `pages`
+
+Este diretório contém as visualizações e rotas de sua aplicação. Nuxt lerá todos os arquivos `*.vue` dentro deste diretório e configurará o Vue Router automaticamente.
+
+Mais informações sobre o uso deste diretório na [documentação](https://nuxtjs.org/docs/2.x/get-started/routing).
+
+### `plugins`
+
+O diretório de plugins contém plugins JavaScript que você deseja executar antes de instanciar o aplicativo Vue.js raiz. Este é o lugar para adicionar plugins Vue e injetar funções ou constantes. Sempre que você precisar usar `Vue.use()`, você deve criar um arquivo em `plugins/` e adicionar seu caminho aos plugins em `nuxt.config.js`.
+
+Mais informações sobre o uso deste diretório na [documentação](https://nuxtjs.org/docs/2.x/directory-structure/plugins).
+
+### `static`
+
+Este diretório contém seus arquivos estáticos. Cada arquivo dentro deste diretório é mapeado para `/`.
+
+Exemplo: `/static/robots.txt` é mapeado como `/robots.txt`.
+
+Mais informações sobre o uso deste diretório na [documentação](https://nuxtjs.org/docs/2.x/directory-structure/static).
+
+### `store`
+
+Este diretório contém seus arquivos de Vuex store. Criar um arquivo neste diretório ativa automaticamente o Vuex.
+
+Mais informações sobre o uso deste diretório na [documentação](https://nuxtjs.org/docs/2.x/directory-structure/store).

--- a/Website/READMEtr.md
+++ b/Website/READMEtr.md
@@ -1,4 +1,4 @@
-Bunu diğer dillerde okuyun: [English](README.md), [Nederlands](READMEnl.md)
+Bunu diğer dillerde okuyun: [English](README.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md)
 
 # youtube-dislike-sayısını-geri-getir-site
 

--- a/Website/_locales/pt_BR.ts
+++ b/Website/_locales/pt_BR.ts
@@ -1,0 +1,125 @@
+import { pt } from "vuetify/src/locale";
+
+export default {
+  ...pt,
+  home: {
+    name: "Início",
+    title: "Return YouTube Dislike",
+    subtitle:
+      "Extensão de navegador e uma API que mostra os dislikes no Youtube",
+    ukraine: "Apoie a Ucrânia",
+    sponsors: "Patrocinadores",
+  },
+  install: {
+    name: "Instalar",
+    title: "Selecione sua Plataforma",
+    subtitle: "Disponível para Firefox e todos os navegadores Chromium",
+    title2: "Outras Plataformas",
+    subtitle2:
+      "Se o seu navegador ainda não for suportado, tente este UserScript",
+    title3: "Implementações de Terceiros",
+    subtitle3: "Sem responsabilidade de nossa parte, use por sua conta e risco",
+  },
+  api: {
+    name: "API",
+    title: "Bem-vindo à documentação oficial do RYD!",
+    subtitle: "Para começar, selecione uma seção no menu.",
+    rights: {
+      title: "Direitos de uso",
+      subtitle:
+        "O uso de terceiros desta API aberta é permitido com as seguintes restrições:",
+      bullet1: "Atribuição: ",
+      bullet1text:
+        "Este projeto deve ser claramente atribuído com um link para este repositório ou um link para returnyoutubedislike.com",
+      bullet2: "Limitação de taxa: ",
+      bullet2text:
+        "Existem limites de taxa por cliente de 100 por minuto e 10.000 por dia. Isso retornará um código de status 429 indicando que sua aplicação deve diminuir a velocidade.",
+    },
+    url: {
+      title: "Informação de URL",
+      subtitle: "A API é acessível no seguinte URL base: ",
+    },
+    endpoints: {
+      title: "Endpoints disponíveis",
+      subtitle: "Lista de endpoints disponíveis está disponível aqui: ",
+    },
+    fetching: {
+      title: "Tutorial Básico de Requisição",
+      subtitle:
+        "Exemplo para obter votos de um vídeo do YouTube com um ID específico:",
+      title2: "Exemplo de Requisição:",
+      url: "URL da Requisição: ",
+      method: "Método da Requisição: ",
+      headers: "Cabeçalhos: ",
+      response: "Resposta: ",
+      error1:
+        'Um ID do YouTube inválido retornará o código de status 404 "Not Found".',
+      error2:
+        'Um ID do YouTube com formato incorreto retornará 400 "Bad Request".',
+    },
+  },
+  help: {
+    name: "Ajuda",
+    title: "Solucionando problemas",
+    bullet1:
+      "Certifique-se de ter a versão mais recente da extensão instalada, ",
+    bullet11: "agora.",
+    bullet2:
+      "Tente remover a extensão e instalá-la novamente, em seguida, reinicie o navegador (todas as janelas ativas, não apenas uma guia).",
+    bullet3: "Certifique-se de que este link abre: ",
+    bullet31: "você deve ver texto simples: ",
+    bullet4: "Se nada disso ajudar - reporte seu problema em",
+    bullet41: "no nosso ",
+    bullet4a: "Informe seu sistema operacional, nome e versão do navegador.",
+    bullet4b:
+      "Tire uma captura de tela da página com o problema (ou seja, página do vídeo do Youtube) com o console aberto (pressione ",
+    bullet4b1: ") - exemplo de captura de tela abaixo.",
+    bullet4c:
+      "Tire uma captura de tela da página de extensões do seu navegador com a extensão instalada.",
+    bullet4c1: "Para ver as extensões, digite isso na barra de endereço: ",
+    firefox: "para Firefox.",
+    chrome: "para Chrome, Edge, Brave, Opera e Vivaldi.",
+  },
+  faq: {
+    name: "FAQ",
+    title: "Perguntas Frequentes",
+    subtitle:
+      "Ainda tem perguntas? Sinta-se à vontade para entrar no nosso Discord!",
+    bullet1: "De onde a extensão obtém seus dados?",
+    bullet1text:
+      "De uma combinação de dados arquivados antes do desligamento oficial da API de deslikes do YouTube e do comportamento dos usuários da extensão extrapolado.",
+    bullet2: "Por que a contagem de deslikes não está sendo atualizada?",
+    bullet2text:
+      "Atualmente, os deslikes dos vídeos são armazenados em cache e não são atualizados com muita frequência. Isso varia dependendo da popularidade do vídeo, mas pode levar de algumas horas a alguns dias para ser atualizado.",
+    bullet3: "Como isso funciona?",
+    bullet3text:
+      "A extensão coleta o ID do vídeo que você está assistindo e busca o número de deslikes (e outros campos como visualizações, likes etc.) usando nossa API. A extensão então exibe a contagem e a proporção de deslikes na página. Se você gosta ou não gosta de um vídeo, isso é registrado e enviado para o banco de dados para que uma contagem precisa de deslikes possa ser extrapolada.",
+    bullet4: "Posso compartilhar minha contagem de deslikes com vocês?",
+    bullet4text:
+      "Em breve. Estamos analisando o uso de Oauth ou uma API somente de leitura com um escopo limitado para que os criadores possam compartilhar suas contagens de deslikes de forma verificável.",
+    bullet5: "Que dados vocês coletam e como eles são tratados?",
+    bullet5text:
+      'A extensão coleta apenas os dados estritamente necessários para que ela funcione corretamente, como o endereço IP ou ID do vídeo que você está assistindo. Nenhum dos seus dados será vendido para terceiros. Se você quiser saber mais sobre como lidamos com segurança e privacidade, confira nosso <a href="https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/SECURITY-FAQptBR.md">FAQ de segurança</a>.',
+    bullet6: "Como funciona a API/backend?",
+    bullet6text:
+      "O backend está usando dados arquivados da época em que a API do YouTube ainda retornava a contagem de deslikes, a contagem de likes/deslikes dos usuários da extensão e a extrapolação. Em um futuro próximo, permitiremos que os criadores de conteúdo enviem sua contagem de deslikes facilmente e com segurança e adicionaremos os dados arquivados do ArchiveTeam (4,56 bilhões de vídeos) em nosso banco de dados atual. Você também pode assistir a um vídeo sobre o assunto.",
+    bullet7: "Por que a contagem de deslikes mostra 'DESLIKES DESATIVADOS'?",
+    bullet7text:
+      "Às vezes, um vídeo recentemente carregado pode mostrar 'DESLIKES DESATIVADOS', mesmo que o criador não o tenha desativado. Isso ocorre devido à forma como estamos detectando se os deslikes estão desativados e deve desaparecer em algumas horas ou ao gostar ou não gostar do vídeo e atualizar a página (esperançosamente).",
+  },
+  donate: {
+    name: "Doar",
+    subtitle:
+      "Você pode apoiar nossos esforços para manter a internet livre com uma doação!",
+  },
+  links: {
+    name: "Links",
+    title: "Links do Projeto",
+    subtitle: "Links para o projeto e seus desenvolvedores",
+    contact: "Entre em Contato",
+    translators: "Tradutores",
+    coolProjects: "Projetos Legais",
+    sponsorBlockDescription: "Pula anúncios integrados ao vídeo",
+    filmotDescription: "Busca vídeos no YouTube por meio das legendas",
+  },
+};

--- a/Website/layouts/default.vue
+++ b/Website/layouts/default.vue
@@ -106,6 +106,7 @@ export default {
       { name: "Čeština", locale: "cs" },
       { name: "日本語", locale: "ja" },
       { name: "Français", locale: "fr" },
+      { name: "Português (Brasil)", locale: "pt_BR" },
       // { name: "Deutsch", locale: "de" },
       { name: "Українська", locale: "uk" },
       { name: "한국어", locale: "ko" },

--- a/Website/nuxt.config.js
+++ b/Website/nuxt.config.js
@@ -7,6 +7,7 @@ import ja from "./_locales/ja";
 import fr from "./_locales/fr";
 import uk from "./_locales/uk";
 import ko from "./_locales/ko";
+import pt_BR from "./_locales/pt_BR";
 // import de from "./_locales/de";
 // ...
 export default {
@@ -52,7 +53,7 @@ export default {
   // Vuetify module configuration: https://go.nuxtjs.dev/config-vuetify
   vuetify: {
     lang: {
-      locales: { en, es, tr, ru, cs, ja, fr, uk, ko /* de, ...*/ },
+      locales: { en, es, tr, ru, cs, ja, fr, uk, ko, pt_BR /* de, ...*/ },
       current: "en",
     },
     theme: {

--- a/Website/pages/links.vue
+++ b/Website/pages/links.vue
@@ -117,6 +117,10 @@ export default {
         tag: "dsty#1614",
         lang: "Українська",
       },
+      {
+        tag: "Luz#5102",
+        lang: "Português (Brasil)",
+      },
     ],
     coolProjects: [
       {

--- a/Website/store/README.md
+++ b/Website/store/README.md
@@ -1,4 +1,4 @@
-Read this in other languages: [Nederlands](READMEnl.md), [Türkçe](READMEtr.md)
+Read this in other languages: [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md), [Türkçe](READMEtr.md)
 
 # STORE
 

--- a/Website/store/READMEnl.md
+++ b/Website/store/READMEnl.md
@@ -1,4 +1,4 @@
-Read this in other languages: [English](READMEen.md), [Türkçe](READMEtr.md)
+Read this in other languages: [English](READMEen.md), [Português (Brasil)](READMEpt-br.md), [Türkçe](READMEtr.md)
 
 # OPSLAAN
 

--- a/Website/store/READMEpt-br.md
+++ b/Website/store/READMEpt-br.md
@@ -1,4 +1,4 @@
-Leia em outros idiomas: [Nederlands](READMEnl.md), [Türkçe](READMEtr.md)
+Leia em outros idiomas: [English](READMEen.md), [Nederlands](READMEnl.md), [Türkçe](READMEtr.md)
 
 # STORE
 

--- a/Website/store/READMEpt-br.md
+++ b/Website/store/READMEpt-br.md
@@ -1,0 +1,12 @@
+Leia em outros idiomas: [Nederlands](READMEnl.md), [Türkçe](READMEtr.md)
+
+# STORE
+
+**Este diretório não é obrigatório, você pode excluí-lo se não quiser usá-lo.**
+
+Este diretório contém seus arquivos de Vuex Store.
+A opção de Vuex Store é implementada no framework Nuxt.js.
+
+Criar um arquivo neste diretório ativa automaticamente a opção no framework.
+
+Mais informações sobre o uso deste diretório na [documentação](https://nuxtjs.org/guide/vuex-store).

--- a/Website/store/READMEtr.md
+++ b/Website/store/READMEtr.md
@@ -1,4 +1,4 @@
-Bunu diğer dillerde okuyun: [English](README.md)
+Bunu diğer dillerde okuyun: [English](READMEen.md), [Nederlands](READMEnl.md), [Português (Brasil)](READMEpt-br.md)
 
 # MAĞAZA
 

--- a/extension-description-store-brazilian-portuguese.txt
+++ b/extension-description-store-brazilian-portuguese.txt
@@ -1,0 +1,20 @@
+Return YouTube Dislike restaura a habilidade de ver os dislikes no YouTube.
+
+Se não funcionar: abra a guia de Extensões (chrome://extensions/), desative esta extensão e ative-a novamente. Isso deve corrigir a maioria dos problemas, já que há um bug no Chromium que quebra a extensão em alguns casos. Esperamos que a equipe do Chromium resolva isso em breve.
+
+A partir de 13 de dezembro de 2021, o YouTube removeu de sua API a capacidade de ver dislikes.
+Esta extensão tem como objetivo devolver o poder aos usuários, usando uma combinação de dados arquivados de likes e dislikes, bem como os likes e dislikes feitos pelos usuários da extensão para mostrar as avaliações mais precisas.
+
+Atualmente possui dados de mais de 200 milhões de likes e dislikes de vídeos armazenados antes de 13 de dezembro de 2021.
+
+Está em constante crescimento e mantendo-se atualizada com os uploads após 13 de dezembro de 2021.
+
+Quanto mais usuários usarem a extensão, mais precisa ela será.
+
+Vídeos impopulares enviados após 13 de dezembro de 2021 podem ter dados menos precisos do que vídeos mais populares.
+
+Esta extensão está atualmente em fase de desenvolvimento ativo, portanto, se você tiver algum problema, não hesite em relatá-lo em nossa página do GitHub ou em nosso servidor do Discord.
+
+Mais recursos em breve!
+
+https://github.com/Anarios/return-youtube-dislike


### PR DESCRIPTION
Brazilian Portuguese translation added on Website and Markdown files.
Reference to other translations updated and organized in alphabetical order (using the order that the corresponding file in other languages appears). There were some references besides Brazilian Portuguese missing, that was also added.
Small correction in the FAQ, fixed the visualization link of the video explaining the extension.