### PR TITLE
fix get count dislikes on mobile version of youtube

### DIFF
--- a/Extensions/combined/ryd.content-script.js
+++ b/Extensions/combined/ryd.content-script.js
@@ -44,16 +44,24 @@ import {
 initExtConfig();
 
 let jsInitChecktimer = null;
+let isSetInitialStateDone = false;
 
 function setEventListeners(evt) {
   function checkForJS_Finish() {
     if (isShorts() || (getButtons()?.offsetParent && isVideoLoaded())) {
       addLikeDislikeEventListener();
       setInitialState();
+      isSetInitialStateDone = true;
       getBrowser().storage.onChanged.addListener(storageChangeHandler);
       clearInterval(jsInitChecktimer);
       jsInitChecktimer = null;
     }
+  }
+
+
+  if(!isSetInitialStateDone) {
+    cLog('init fallback solution for getting dislikes')
+    setInitialState();
   }
 
   jsInitChecktimer = setInterval(checkForJS_Finish, 111);

--- a/Extensions/combined/ryd.content-script.js
+++ b/Extensions/combined/ryd.content-script.js
@@ -48,21 +48,22 @@ let isSetInitialStateDone = false;
 
 function setEventListeners(evt) {
   function checkForJS_Finish() {
-    if (isShorts() || (getButtons()?.offsetParent && isVideoLoaded())) {
-      addLikeDislikeEventListener();
-      setInitialState();
-      isSetInitialStateDone = true;
-      getBrowser().storage.onChanged.addListener(storageChangeHandler);
-      clearInterval(jsInitChecktimer);
-      jsInitChecktimer = null;
+    try {
+      if (isShorts() || (getButtons()?.offsetParent && isVideoLoaded())) {
+        addLikeDislikeEventListener();
+        setInitialState();
+        isSetInitialStateDone = true;
+        getBrowser().storage.onChanged.addListener(storageChangeHandler);
+        clearInterval(jsInitChecktimer);
+        jsInitChecktimer = null;
+      } 
+    } catch(exception) {
+      if(!isSetInitialStateDone) {
+        setInitialState();
+      }
     }
   }
 
-
-  if(!isSetInitialStateDone) {
-    cLog('init fallback solution for getting dislikes')
-    setInitialState();
-  }
 
   jsInitChecktimer = setInterval(checkForJS_Finish, 111);
 }

--- a/Extensions/combined/src/events.js
+++ b/Extensions/combined/src/events.js
@@ -85,9 +85,11 @@ function dislikeClicked() {
 function addLikeDislikeEventListener() {
   if (!window.returnDislikeButtonlistenersSet) {
     getLikeButton().addEventListener("click", likeClicked);
-    getDislikeButton().addEventListener("click", dislikeClicked);
     getLikeButton().addEventListener("touchstart", likeClicked);
-    getLikeButton().addEventListener("touchstart", dislikeClicked);
+    if(getDislikeButton()) {
+      getDislikeButton().addEventListener("click", dislikeClicked);
+      getDislikeButton().addEventListener("touchstart", dislikeClicked);
+    }
     window.returnDislikeButtonlistenersSet = true;
   }
 }


### PR DESCRIPTION
The pull request fixes getting dislikes on the mobile version of the site.
It fixes it in two ways.
1. Checking the existence of the dislikes button before adding a listener to increase the number of dislikes.
2. An alternative solution, in case the error still occurred. (Possibly requires a fix, because it is performed without delay)

Problem founded in compiled code:
![изображение](https://user-images.githubusercontent.com/9301662/222945941-732f471f-0d62-43b7-8ac3-4f10e557d59e.png)

```js
buttons.children[0].children[0].addEventListener("click", likeClicked);
buttons.children[0].children[1].addEventListener("click", dislikeClicked);
buttons.children[0].children[0].addEventListener("touchstart", likeClicked);
buttons.children[0].children[1].addEventListener("touchstart", dislikeClicked);
```

buttons.children[0].children[1] is undefined

Why getDislikesButtons() compiled to buttons.children[0].children[1] i don't know.

