### PR TITLE
Add Safari extension build target

### DIFF
--- a/Extensions/combined/manifest-safari.json
+++ b/Extensions/combined/manifest-safari.json
@@ -1,0 +1,36 @@
+{
+  "name": "__MSG_extensionName__",
+  "description": "__MSG_extensionDesc__",
+  "default_locale": "en",
+  "version": "3.0.0.8",
+  "manifest_version": 2,
+  "background": {
+    "scripts": ["ryd.background.js"],
+    "persistent": false
+  },
+  "icons": {
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "permissions": [
+    "activeTab",
+    "*://*.youtube.com/*",
+    "storage",
+    "*://returnyoutubedislikeapi.com/*"
+  ],
+  "browser_action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["*://*.youtube.com/*"],
+      "exclude_matches": ["*://*.music.youtube.com/*"],
+      "run_at": "document_idle",
+      "css": ["content-style.css"],
+      "js": ["ryd.content-script.js"]
+    }
+  ],
+  "options_ui": {
+    "page": "popup.html"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "echo To build for development, please use \"npm run dev\". To build for production, please use \"npm run build\".",
     "dev": "webpack --mode=production --watch",
     "build": "webpack --mode=production",
+    "build:safari": "webpack --mode=production && xcrun safari-web-extension-converter Extensions/combined/dist/safari --project-location Extensions/combined/dist --bundle-identifier com.returnyoutubedislike.safari-ext --force",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,17 @@ module.exports = {
           from: "./Extensions/combined/manifest-firefox.json",
           to: "./firefox/manifest.json",
         },
+        {
+          from: "./Extensions/combined",
+          to: "./safari",
+          globOptions: {
+            ignore: ignorePatterns,
+          },
+        },
+        {
+          from: "./Extensions/combined/manifest-safari.json",
+          to: "./safari/manifest.json",
+        },
       ],
     }),
     new FileManagerPlugin({
@@ -69,6 +80,10 @@ module.exports = {
             {
               source: "./Extensions/combined/dist/**.js",
               destination: "./Extensions/combined/dist/chrome/",
+            },
+            {
+              source: "./Extensions/combined/dist/**.js",
+              destination: "./Extensions/combined/dist/safari/",
             },
           ],
         },


### PR DESCRIPTION
This is an alternative implementation to those in #133, #443, and #487.

Similarly to #443, this adds a Safari extension as a webpack plugin pattern. It then generates an Xcode project for the macOS and iOS apps using a build script in `package.json`.

Building the Safari extension now requires only one short command. Running `npm run build:safari` will run the standard webpack build steps, and then invokes the Xcode Safari extension generator to create an Xcode project. All files generated by doing this will be found under `Extensions/combined/dist`. At this point, the Xcode project opens automatically and one can compile and export copies of the Mac and iOS Safari extensions.

What I did differently from the other PRs is I treated the Xcode project as a build artifact, rather than treat it as part of the codebase for the extension. Not only does it keep the repo’s directory structure easy on the eyes, but it can be beneficial for other reasons. It ensures the Mac and iOS apps are always made ”cleanly”. Future Xcode releases may change aspects of how it generates Safari extension projects (I believe this already had happened in the past), so avoiding ”hard-coding” the Xcode project as part of the extension’s codebase might avoid problems down the line.

I exported a Safari extension and tested it on Safari 16.3 and 16.4 on macOS 13.3 and iOS 16.3, and all functionality appears identical to that of the extension on Firefox and Chrome.
</br>
</br>

@rdev, @CamilleScholtz, @1998code, curious to hear your thoughts as you submitted the PRs that I mentioned.