### PR TITLE
Fix incompatibilities with some userscripts

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -2,7 +2,7 @@
 // @name         Return YouTube Dislike
 // @namespace    https://www.returnyoutubedislike.com/
 // @homepage     https://www.returnyoutubedislike.com/
-// @version      3.1.2
+// @version      3.1.3
 // @encoding     utf-8
 // @description  Return of the YouTube Dislike, Based off https://www.returnyoutubedislike.com/
 // @icon         https://github.com/Anarios/return-youtube-dislike/raw/main/Icons/Return%20Youtube%20Dislike%20-%20Transparent.png
@@ -102,14 +102,14 @@ function getButtons() {
 function getDislikeButton() {
   return getButtons().children[0].tagName ===
   "YTD-SEGMENTED-LIKE-DISLIKE-BUTTON-RENDERER"
-    ? getButtons().children[0].children[1] === undefined ? document.querySelector("#segmented-dislike-button") : getButtons().children[0].children[1]
+    ? getButtons().children[0].children[1] === undefined ? getButtons().children[0].querySelector("#segmented-dislike-button") : getButtons().children[0].children[1]
     : getButtons().children[1];
 }
 
 function getLikeButton() {
   return getButtons().children[0].tagName ===
   "YTD-SEGMENTED-LIKE-DISLIKE-BUTTON-RENDERER"
-    ? document.querySelector("#segmented-like-button") !== null ? document.querySelector("#segmented-like-button") : getButtons().children[0].children[0]
+    ? getButtons().children[0].querySelector("#segmented-like-button") !== null ? getButtons().children[0].querySelector("#segmented-like-button") : getButtons().children[0].children[0]
     : getButtons().children[0];
 }
 

--- a/Extensions/combined/src/buttons.js
+++ b/Extensions/combined/src/buttons.js
@@ -35,7 +35,7 @@ function getButtons() {
 function getLikeButton() {
   return getButtons().children[0].tagName ===
     "YTD-SEGMENTED-LIKE-DISLIKE-BUTTON-RENDERER"
-    ? document.querySelector("#segmented-like-button") !== null ? document.querySelector("#segmented-like-button") : getButtons().children[0].children[0]
+    ? getButtons().children[0].querySelector("#segmented-like-button") !== null ? getButtons().children[0].querySelector("#segmented-like-button") : getButtons().children[0].children[0]
     : getButtons().children[0];
 }
 
@@ -50,7 +50,7 @@ function getLikeTextContainer() {
 function getDislikeButton() {
   return getButtons().children[0].tagName ===
     "YTD-SEGMENTED-LIKE-DISLIKE-BUTTON-RENDERER"
-    ? getButtons().children[0].children[1] === undefined ? document.querySelector("#segmented-dislike-button") : getButtons().children[0].children[1]
+    ? getButtons().children[0].children[1] === undefined ? getButtons().children[0].querySelector("#segmented-dislike-button") : getButtons().children[0].children[1]
     : getButtons().children[1];
 }
 


### PR DESCRIPTION
Fixes compatibility with scripts that revert the description layout such as ['Youtube Watch Page Fix'](https://greasyfork.org/en/scripts/445015-youtube-watch-page-fix) and ['Youtube Proper Description'](https://greasyfork.org/en/scripts/440613-youtube-proper-description), as described in issue #735.
Tested on desktop & mobile and it seems to be working all the same without those scripts, but let me know if you find anything misbehaving.