### PR TITLE
don't show dislike count on share button - fixes #948

### DIFF
--- a/Extensions/combined/src/buttons.js
+++ b/Extensions/combined/src/buttons.js
@@ -50,7 +50,10 @@ function getLikeTextContainer() {
 function getDislikeButton() {
   return getButtons().children[0].tagName ===
     "YTD-SEGMENTED-LIKE-DISLIKE-BUTTON-RENDERER"
-    ? getButtons().children[0].children[1] === undefined ? document.querySelector("#segmented-dislike-button") : getButtons().children[0].children[1]
+    ? (getButtons().children[0].children[1] === undefined ? document.querySelector("#segmented-dislike-button") : getButtons().children[0].children[1])
+    
+    : getButtons().children[0].tagName === "segmented-like-dislike-button-view-model"
+    ? getButtons().children[0].querySelector("dislike-button-view-model")
     : getButtons().children[1];
 }
 


### PR DESCRIPTION
There must've been some Youtube update, because the tags in the inspector were slightly different. I updated the selector in `getDislikeButton()` so it correctly points to the new dislike button.

I tested the fix and _it works on my machine_ at least, with Firefox 119.0 on Windows 11.