### PR TITLE
Implemented centralized versioning

### DIFF
--- a/Extensions/combined/_locales/cs/messages.json
+++ b/Extensions/combined/_locales/cs/messages.json
@@ -42,7 +42,7 @@
     "message": "aktualizovat na"
   },
   "version30installed": {
-    "message": "Verze 3.0.0.13 nainstalována"
+    "message": "Verze __RYD_VERSION__ nainstalována"
   },
   "whatsnew": {
     "message": "Co je nového"

--- a/Extensions/combined/_locales/de/messages.json
+++ b/Extensions/combined/_locales/de/messages.json
@@ -36,7 +36,7 @@
     "message": "aktualisieren auf"
   },
   "version30installed": {
-    "message": "Version 3.0.0.13 installiert"
+    "message": "Version __RYD_VERSION__ installiert"
   },
   "whatsnew": {
     "message": "Was ist neu"

--- a/Extensions/combined/_locales/el/messages.json
+++ b/Extensions/combined/_locales/el/messages.json
@@ -84,7 +84,7 @@
     "message": "Ενημέρωση σε"
   },
   "version30installed": {
-    "message": "Εκδοση 3.0.0.13 εγκαταστάθηκε"
+    "message": "Εκδοση __RYD_VERSION__ εγκαταστάθηκε"
   },
   "whatsnew": {
     "message": "Τί νέο υπάρχει"

--- a/Extensions/combined/_locales/en/messages.json
+++ b/Extensions/combined/_locales/en/messages.json
@@ -84,7 +84,7 @@
     "message": "Update to"
   },
   "version30installed": {
-    "message": "Version 3.0.0.13 installed"
+    "message": "Version __RYD_VERSION__ installed"
   },
   "whatsnew": {
     "message": "What's new"

--- a/Extensions/combined/_locales/es/messages.json
+++ b/Extensions/combined/_locales/es/messages.json
@@ -84,7 +84,7 @@
     "message": "actualizar a"
   },
   "version30installed": {
-    "message": "Versión 3.0.0.13 instalada"
+    "message": "Versión __RYD_VERSION__ instalada"
   },
   "whatsnew": {
     "message": "Novedades"

--- a/Extensions/combined/_locales/fr/messages.json
+++ b/Extensions/combined/_locales/fr/messages.json
@@ -42,7 +42,7 @@
     "message": "mettre à jour vers"
   },
   "version30installed": {
-    "message": "Version 3.0.0.13 installée"
+    "message": "Version __RYD_VERSION__ installée"
   },
   "whatsnew": {
     "message": "Quoi de neuf"

--- a/Extensions/combined/_locales/it/messages.json
+++ b/Extensions/combined/_locales/it/messages.json
@@ -36,7 +36,7 @@
     "message": "aggiorna a"
   },
   "version30installed": {
-    "message": "Versione 3.0.0.13 installata"
+    "message": "Versione __RYD_VERSION__ installata"
   },
   "whatsnew": {
     "message": "Quali sono le novità"

--- a/Extensions/combined/_locales/ja/messages.json
+++ b/Extensions/combined/_locales/ja/messages.json
@@ -42,7 +42,7 @@
     "message": "アップデート："
   },
   "version30installed": {
-    "message": "バージョン 3.0.0.13 がインストールされました。"
+    "message": "バージョン __RYD_VERSION__ がインストールされました。"
   },
   "whatsnew": {
     "message": "新機能"

--- a/Extensions/combined/_locales/ko/messages.json
+++ b/Extensions/combined/_locales/ko/messages.json
@@ -84,7 +84,7 @@
     "message": "업데이트"
   },
   "version30installed": {
-    "message": "3.0.0.13 버전이 설치됨"
+    "message": "__RYD_VERSION__ 버전이 설치됨"
   },
   "whatsnew": {
     "message": "새로운 점"

--- a/Extensions/combined/_locales/nl/messages.json
+++ b/Extensions/combined/_locales/nl/messages.json
@@ -84,7 +84,7 @@
     "message": "Update naar"
   },
   "version30installed": {
-    "message": "Versie 3.0.0.13 geïnstalleerd"
+    "message": "Versie __RYD_VERSION__ geïnstalleerd"
   },
   "whatsnew": {
     "message": "Wat is er nieuw"

--- a/Extensions/combined/_locales/pl/messages.json
+++ b/Extensions/combined/_locales/pl/messages.json
@@ -84,7 +84,7 @@
     "message": "Zaktualizuj do"
   },
   "version30installed": {
-    "message": "Zainstalowana wersja 3.0.0.1"
+    "message": "Zainstalowana wersja __RYD_VERSION__"
   },
   "whatsnew": {
     "message": "Co nowego"

--- a/Extensions/combined/_locales/pt_BR/messages.json
+++ b/Extensions/combined/_locales/pt_BR/messages.json
@@ -42,7 +42,7 @@
     "message": "Atualizar para"
   },
   "version30installed": {
-    "message": "Versão 3.0.0.13 instalada"
+    "message": "Versão __RYD_VERSION__ instalada"
   },
   "whatsnew": {
     "message": "O que há de novo?"

--- a/Extensions/combined/_locales/ru/messages.json
+++ b/Extensions/combined/_locales/ru/messages.json
@@ -36,7 +36,7 @@
     "message": "обновление до"
   },
   "version30installed": {
-    "message": "Версия 3.0.0.13 установлена"
+    "message": "Версия __RYD_VERSION__ установлена"
   },
   "whatsnew": {
     "message": "Что нового"

--- a/Extensions/combined/_locales/sv_SE/messages.json
+++ b/Extensions/combined/_locales/sv_SE/messages.json
@@ -84,7 +84,7 @@
     "message": "Uppdatera till"
   },
   "version30installed": {
-    "message": "Version 3.0.0.13 installerad"
+    "message": "Version __RYD_VERSION__ installerad"
   },
   "whatsnew": {
     "message": "Vad är nytt"

--- a/Extensions/combined/_locales/tr/messages.json
+++ b/Extensions/combined/_locales/tr/messages.json
@@ -84,7 +84,7 @@
     "message": "Şu sürüme güncelle"
   },
   "version30installed": {
-    "message": "Sürüm 3.0.0.13 yüklendi"
+    "message": "Sürüm __RYD_VERSION__ yüklendi"
   },
   "whatsnew": {
     "message": "Yeni Ne Var"

--- a/Extensions/combined/_locales/uk/messages.json
+++ b/Extensions/combined/_locales/uk/messages.json
@@ -84,7 +84,7 @@
     "message": "Оновлення до"
   },
   "version30installed": {
-    "message": "Версію 3.0.0.13 встановлено"
+    "message": "Версію __RYD_VERSION__ встановлено"
   },
   "whatsnew": {
     "message": "Що нового"

--- a/Extensions/combined/manifest-chrome.json
+++ b/Extensions/combined/manifest-chrome.json
@@ -2,7 +2,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "3.0.0.14",
+  "version": "__RYD_VERSION__",
   "manifest_version": 3,
   "background": {
     "service_worker": "ryd.background.js"

--- a/Extensions/combined/manifest-firefox.json
+++ b/Extensions/combined/manifest-firefox.json
@@ -2,7 +2,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "3.0.0.14",
+  "version": "__RYD_VERSION__",
   "manifest_version": 2,
   "background": {
     "scripts": ["ryd.background.js"]

--- a/Extensions/combined/manifest-safari.json
+++ b/Extensions/combined/manifest-safari.json
@@ -2,7 +2,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "3.0.0.8",
+  "version": "__RYD_VERSION__",
   "manifest_version": 2,
   "background": {
     "scripts": ["ryd.background.js"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "return-youtube-dislike",
-  "version": "2.0.0",
+  "version": "3.0.0-14",
   "description": "Chrome extension to return youtube dislikes",
   "main": "ryd.content-script.js",
   "scripts": {


### PR DESCRIPTION
Version numbers were all over the place - different versions in localization files (`3.0.0.13`, and `3.0.0.1` in PL), GitHub manifest (`3.0.0.12`), extension stores manifest (`3.0.0.14`), and `package.json` (`2.0.0`).

This pull request aims to fix the problem by changing all the version references except for one in `package.json` to template strings. These template strings will be replaced to the actual build number from `package.json` at build time.

Because versioning scheme of this project is not compatible with SemVer, it looks different in `package.json` (e.g. `3.0.0-14` instead of `3.0.0.14`), but it's converted back to the currently used versioning scheme during the build.