### PR TITLE
GitHub Actions - build extension on commits and pull requests to main branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,53 @@
+name: Test Build Extension
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Extensions/combined/**
+
+  pull_request:
+    branches: [main]
+    paths:
+      - Extensions/combined/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./Extensions/combined
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension
+        run: npm run build
+
+      - name: 'Upload Chrome artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ryd-chrome
+          path: ./Extensions/combined/dist/chrome
+
+      - name: 'Upload Firefox artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ryd-firefox
+          path: ./Extensions/combined/dist/firefox
+
+      - name: 'Upload Safari artifact'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ryd-safari
+          path: ./Extensions/combined/dist/safari


### PR DESCRIPTION
Adds a GitHub workflow for building and providing an unpacked extension build, triggered on commits and pull requests to `main` branch.

This a first step for #1003 - and can be used as a foundation for automated signed crx builds and [pre-release](https://github.com/Anarios/return-youtube-dislike/releases) publication in the future.