### PR TITLE
Extension - New (spring 2024) UI support

### DIFF
--- a/Extensions/combined/src/utils.js
+++ b/Extensions/combined/src/utils.js
@@ -98,6 +98,9 @@ function isInViewport(element) {
 function isVideoLoaded() {
   const videoId = getVideoId(window.location.href);
   return (
+    // desktop: spring 2024 UI
+    document.querySelector(`ytd-watch-grid[video-id='${videoId}']`) !== null ||
+    // desktop: older UI
     document.querySelector(`ytd-watch-flexy[video-id='${videoId}']`) !== null ||
     // mobile: no video-id attribute
     document.querySelector('#player[loading="false"]:not([hidden])') !== null

--- a/Extensions/combined/src/utils.js
+++ b/Extensions/combined/src/utils.js
@@ -18,9 +18,7 @@ function getNumberFormatter(optionSelect) {
           ?.getAttribute("href"),
       )?.searchParams?.get("locale");
     } catch {
-      cLog(
-        "Cannot find browser locale. Use en as default for number formatting.",
-      );
+      cLog("Cannot find browser locale. Use en as default for number formatting.");
       userLocales = "en";
     }
   }
@@ -56,10 +54,7 @@ function localize(localeString) {
 function getBrowser() {
   if (typeof chrome !== "undefined" && typeof chrome.runtime !== "undefined") {
     return chrome;
-  } else if (
-    typeof browser !== "undefined" &&
-    typeof browser.runtime !== "undefined"
-  ) {
+  } else if (typeof browser !== "undefined" && typeof browser.runtime !== "undefined") {
     return browser;
   } else {
     console.log("browser is not supported");


### PR DESCRIPTION
Add support for new UI. Fixes #1043

Tested with both new and old UI (since it's in a A/B testing phase) on Windows with :
- Firefox Dev 125.0b6
- Edge Dev 125.0.2518.0
- Chrome 124.0.6367.61 (PortableApps version)

And on Linux (KUbuntu)  with :
- Firefox Dev 125.0.1
- Edge Dev 125.0.2492.1

Preview of the extension working with the new UI:
![image](https://github.com/Anarios/return-youtube-dislike/assets/7818904/f2d88c8c-109c-4bce-9efa-1576fb43ae0f)
