### PR TITLE
Extension - fix spring 2024 UI buttons position

### DIFF
--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -95,13 +95,6 @@ function createRateBar(likes, dislikes) {
           descriptionAndActionsElement.style.borderBottom =
             "1px solid var(--yt-spec-10-percent-layer)";
           descriptionAndActionsElement.style.paddingBottom = "10px";
-
-          // Fix like/dislike ratio bar offset in new UI
-          document.getElementById("actions-inner").style.width = "revert";
-          if (isRoundedDesign()) {
-            document.getElementById("actions").style.flexDirection =
-              "row-reverse";
-          }
         }
       } else {
         document.querySelector(`.ryd-tooltip`).style.width = widthPx + "px";


### PR DESCRIPTION
With the new (spring 2024) UI, action buttons are aligned to the left but an obsolete patch made them align to the right instead.

This commit removes this obsolete patch in order to restore the original alignment (left for new UI and no changes/right for the previous UI).

Tested with the new and previous UI (Firefox and Edge on Windows) with and without the ratio bar

Screenshot of the issue:
[<img src="https://github.com/Anarios/return-youtube-dislike/assets/7818904/7c0378fc-e168-4b1c-901d-55e264218c8b" width="500">](https://github.com/Anarios/return-youtube-dislike/assets/7818904/7c0378fc-e168-4b1c-901d-55e264218c8b)

What it's supposed to look like (RYD extension disabled) :
[<img src="https://github.com/Anarios/return-youtube-dislike/assets/7818904/b586f265-8433-4ed4-a691-56ded481880c" width="500">](https://github.com/Anarios/return-youtube-dislike/assets/7818904/b586f265-8433-4ed4-a691-56ded481880c)

Screenshot of the provided fix:
[<img src="https://github.com/Anarios/return-youtube-dislike/assets/7818904/71db7120-a20e-42fd-8a82-c8426b496d6f" width="500">](https://github.com/Anarios/return-youtube-dislike/assets/7818904/71db7120-a20e-42fd-8a82-c8426b496d6f)