### PR TITLE
Unobserved child node removals

### DIFF
--- a/Extensions/UserScript/Return Youtube Dislike.user.js
+++ b/Extensions/UserScript/Return Youtube Dislike.user.js
@@ -258,8 +258,12 @@ function setDislikes(dislikesCount) {
     mobileDislikes = dislikesCount;
     return;
   }
-  getDislikeTextContainer()?.removeAttribute("is-empty");
-  getDislikeTextContainer().innerText = dislikesCount;
+
+  const _container = getDislikeTextContainer();
+  _container?.removeAttribute("is-empty");
+  if (_container?.innerText !== dislikesCount) {
+    _container.innerText = dislikesCount;
+  }
 }
 
 function getLikeCountFromButton() {
@@ -648,6 +652,7 @@ function setEventListeners(evt) {
               {
                 attributes: true,
                 subtree: true,
+                childList: true,
               },
               updateDOMDislikes,
             );

--- a/Extensions/combined/src/events.js
+++ b/Extensions/combined/src/events.js
@@ -116,6 +116,7 @@ function createSmartimationObserver() {
       {
         attributes: true,
         subtree: true,
+        childList: true,
       },
       updateDOMDislikes,
     );

--- a/Extensions/combined/src/state.js
+++ b/Extensions/combined/src/state.js
@@ -156,20 +156,28 @@ function setLikes(likesCount) {
 
 function setDislikes(dislikesCount) {
   cLog(`SET dislikes ${dislikesCount}`);
-  getDislikeTextContainer()?.removeAttribute("is-empty");
+
+  const _container = getDislikeTextContainer();
+  _container?.removeAttribute("is-empty");
+
+  let _dislikeText
   if (!isLikesDisabled()) {
     if (isMobile()) {
       getButtons().children[1].querySelector(".button-renderer-text").innerText = dislikesCount;
       return;
     }
-    getDislikeTextContainer().innerText = dislikesCount;
+    _dislikeText = dislikesCount;
   } else {
     cLog("likes count disabled by creator");
     if (isMobile()) {
       getButtons().children[1].querySelector(".button-renderer-text").innerText = localize("TextLikesDisabled");
       return;
     }
-    getDislikeTextContainer().innerText = localize("TextLikesDisabled");
+    _dislikeText = localize("TextLikesDisabled");
+  }
+
+  if (_dislikeText != null && _container?.innerText !== _dislikeText) {
+    _container.innerText = _dislikeText;
   }
 }
 


### PR DESCRIPTION
Due to a recent youtube update, like/dislike buttons may re-render causing "foreign" elements to get cleared