### PR TITLE
Infinite register/vote loop on sendVote returning 401

### DIFF
--- a/Extensions/combined/ryd.background.js
+++ b/Extensions/combined/ryd.background.js
@@ -96,7 +96,7 @@ api.runtime.onInstalled.addListener((details) => {
 //   }
 // });
 
-async function sendVote(videoId, vote) {
+async function sendVote(videoId, vote, depth = 1) {
   api.storage.sync.get(null, async (storageResult) => {
     if (!storageResult.userId || !storageResult.registrationConfirmed) {
       await register();
@@ -113,11 +113,14 @@ async function sendVote(videoId, vote) {
       }),
     });
 
-    if (voteResponse.status == 401) {
+    if (voteResponse.status == 401 && depth > 0) {
       await register();
-      await sendVote(videoId, vote);
+      await sendVote(videoId, vote, depth-1);
+      return;
+    } else if (voteResponse.status == 401) { // We have already tried registering
       return;
     }
+
     const voteResponseJson = await voteResponse.json();
     const solvedPuzzle = await solvePuzzle(voteResponseJson);
     if (!solvedPuzzle.solution) {


### PR DESCRIPTION
When a registered user receives a 401 upon voting, it will generate a new userId and register it. 
However, if the server repeatedly returns 401 for the same user every time, the user will get stuck in a voting loop that will spam request to the /vote endpoint and spike the users CPU usage on running solvePuzzle

This change adds a safeguard against this infinite loop edgecase and prevents liking a video to spike the users CPU