### PR TITLE
fix: ratio bar disappearing on scroll

### DIFF
--- a/Extensions/combined/src/bar.js
+++ b/Extensions/combined/src/bar.js
@@ -13,10 +13,7 @@ function createRateBar(likes, dislikes) {
   let rateBar = document.getElementById("ryd-bar-container");
   if (!isLikesDisabled()) {
     // sometimes rate bar is hidden
-    if (rateBar && !isInViewport(rateBar)) {
-      rateBar.remove();
-      rateBar = null;
-    }
+
 
     const widthPx =
       parseFloat(window.getComputedStyle(getLikeButton()).width) +


### PR DESCRIPTION
## what this fixes

fixes the ratio bar disappearing when you scroll. turns out there was a check that removed the bar element whenever it left the viewport, but it didn't come back unless you clicked something.

## related issue
fixes #1252

## changes
removed the `isInViewport` check in `src/bar.js` that was calling `rateBar.remove()`. 

the bar now just stays in the dom. when `createRateBar` gets called (either from navigation or voting), it updates the existing bar instead of trying to recreate it. way simpler.

## why the old code existed
dug through the git history - the `isInViewport` thing was added in commit b5382bab (nov 2022) to deal with "ghost elements" from youtube's spa navigation. 

makes sense in theory, but it had a flaw: it couldn't tell the difference between a stale element and an element that's just off-screen because you scrolled. so it nuked the bar on every scroll.

## testing i did

### scroll test
scrolled down until buttons were off screen, scrolled back up. bar stayed visible. ✓

### checked for memory leaks
navigated through 10+ videos really fast, then ran this in console:
```js
document.querySelectorAll('#ryd-bar-container').length
```
always returned 1, never created duplicates. ✓

### navigation test
clicked between videos, bar updated with new stats immediately. ✓

### other stuff
- shorts: still works fine (they use separate logic)
- mobile: no issues (different code path)
- clicking like/dislike: bar updates correctly

## breaking changes?
nope. just removes some unnecessary dom manipulation.

## why this is safe
- the bar uses a unique id (`ryd-bar-container`), so you can't have duplicates
- when youtube swaps out the ui during navigation, the old bar gets cleaned up automatically by the browser's gc
- modern browsers are already smart about not rendering off-screen elements, so keeping it in the dom doesn't hurt performance

tested locally on firefox & chrome, everything works smoothly.