### PR TITLE
fix: security vulnerabilities in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "country-code-lookup": "^0.1.3",
     "echarts": "^5.5.0",
     "topojson-client": "^3.1.0",
-    "world-atlas": "^2.0.2",
-    "us-atlas": "^3.0.0"
+    "us-atlas": "^3.0.0",
+    "world-atlas": "^2.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",
@@ -42,7 +42,7 @@
     "@babel/runtime": "^7.23.5",
     "babel-loader": "^10.0.0",
     "babel-plugin-rewire": "^1.2.0",
-    "copy-webpack-plugin": "^11.0.0",
+    "copy-webpack-plugin": "^14.0.0",
     "filemanager-webpack-plugin": "^9.0.1",
     "husky": "^9.1.7",
     "jest": "^28.1.3",


### PR DESCRIPTION
## Summary

This PR fixes 3 high severity vulnerabilities in the project dependencies:

- **serialize-javascript** (GHSA-5c6j-r48x-rmvq) - RCE via RegExp.flags and Date.prototype.toISOString()

### Changes

- Update copy-webpack-plugin to ^14.0.0

### Fix Details

Fixed via: `npm audit fix --force`

Reported-by: T14 Security Scanner (zovo.one)