### PR TITLE
fix(deps): resolve 2 high severity security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "country-code-lookup": "^0.1.3",
     "echarts": "^5.5.0",
     "topojson-client": "^3.1.0",
-    "world-atlas": "^2.0.2",
-    "us-atlas": "^3.0.0"
+    "us-atlas": "^3.0.0",
+    "world-atlas": "^2.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",
@@ -42,7 +42,7 @@
     "@babel/runtime": "^7.23.5",
     "babel-loader": "^10.0.0",
     "babel-plugin-rewire": "^1.2.0",
-    "copy-webpack-plugin": "^11.0.0",
+    "copy-webpack-plugin": "^14.0.0",
     "filemanager-webpack-plugin": "^9.0.1",
     "husky": "^9.1.7",
     "jest": "^28.1.3",


### PR DESCRIPTION

## What
Updates copy-webpack-plugin from ^11.0.0 to ^14.0.0 to resolve 2 high severity security vulnerabilities.

## Why
The current version of copy-webpack-plugin depends on serialize-javascript <=7.0.2 which is vulnerable to RCE (GHSA-5c6j-r48x-rmvq). This fix resolves both the serialize-javascript vulnerability and the vulnerable copy-webpack-plugin version.

## How
- Updated copy-webpack-plugin in devDependencies from ^11.0.0 to ^14.0.0
- This is a major version bump but maintains backward compatibility for typical usage

## Testing
- Build passes: `npm run build` ✅
- All 134 tests pass: `npm test` ✅
- 0 vulnerabilities after fix

## References
- GHSA-5c6j-r48x-rmvq: Serialize JavaScript RCE vulnerability
