### PR TITLE
fix(deps): upgrade copy-webpack-plugin to v14.0.0 (npm audit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "country-code-lookup": "^0.1.3",
     "echarts": "^5.5.0",
     "topojson-client": "^3.1.0",
-    "world-atlas": "^2.0.2",
-    "us-atlas": "^3.0.0"
+    "us-atlas": "^3.0.0",
+    "world-atlas": "^2.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",
@@ -42,7 +42,7 @@
     "@babel/runtime": "^7.23.5",
     "babel-loader": "^10.0.0",
     "babel-plugin-rewire": "^1.2.0",
-    "copy-webpack-plugin": "^11.0.0",
+    "copy-webpack-plugin": "^14.0.0",
     "filemanager-webpack-plugin": "^9.0.1",
     "husky": "^9.1.7",
     "jest": "^28.1.3",


### PR DESCRIPTION
## Summary
Resolves 2 high severity security vulnerabilities identified by npm audit:

### Vulnerabilities Fixed
1. **serialize-javascript ReDoS (GHSA-5c6j-r48x-rmvq)**
   - Severity: High
   - Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString()

2. **copy-webpack-plugin vulnerable dependency**
   - copy-webpack-plugin versions 4.3.0 - 13.0.1 depend on vulnerable serialize-javascript

### Changes
- Updated copy-webpack-plugin from the current version to 14.0.0
- This also upgrades serialize-javascript to a safe version

### Testing
- Build verified successfully with `npm run build`

---
*PR created by theluckystrike*