### PR TITLE
docs: add Traditional Chinese (zh-TW) translation and cleanup README language lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEar.md
+++ b/READMEar.md
@@ -8,7 +8,9 @@
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
 Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
-#Return YouTube Dislike
+
+# Return YouTube Dislike
+
 <p align="center">
   <b>إعادة زر عدم الإعجاب على يوتيوب هو امتداد مفتوح المصدر يعيد عرض عدد عدم الإعجاب على يوتيوب.</b><br>
   متاح لمتصفح كروم وفايرفوكس كامتداد ويب.<br>

--- a/READMEar.md
+++ b/READMEar.md
@@ -7,8 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
-
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 #Return YouTube Dislike
 <p align="center">
   <b>إعادة زر عدم الإعجاب على يوتيوب هو امتداد مفتوح المصدر يعيد عرض عدد عدم الإعجاب على يوتيوب.</b><br>

--- a/READMEaz.md
+++ b/READMEaz.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![Lisans](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # YouTube bəyənməmə sayını geri qaytarın
 

--- a/READMEbg.md
+++ b/READMEbg.md
@@ -8,7 +8,7 @@
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 
 

--- a/READMEcn.md
+++ b/READMEcn.md
@@ -7,74 +7,84 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+阅读其他语言版本：[English](README.md)、[العربية](READMEar.md)、[Azərbaycan dili](READMEaz.md)、[български](READMEbg.md)、[繁體中文](READMEtw.md)、[简体中文](READMEcn.md)、[Danish](READMEda.md)、[Deutsch](READMEde.md)、[Español](READMEes.md)、[Français](READMEfr.md)、[Ελληνικά](READMEgr.md)、[Magyar](READMEhu.md)、[Bahasa Indonesia](READMEid.md)、[日本語](READMEja.md)、[한국어](READMEkr.md)、[Nederlands](READMEnl.md)、[Polski](READMEpl.md)、[Português do Brasil](READMEpt_BR.md)、[русский](READMEru.md)、[Svenska](READMEsv.md)、[Türkçe](READMEtr.md)、[українська](READMEuk.md)、[Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 
 <p align="center">
-    <b>Return YouTube Dislike 是一个开源的浏览器扩展，用于显示 YouTube 影片的不喜欢数量。</b><br>
-    适用于 Chrome 和 Firefox 等主流浏览器。<br>
-    同时也提供 JS Userscript 版本，可在其他浏览器上使用。<br><br>
+    <b>Return YouTube Dislike 是一款开源的浏览器扩展程序，可恢复显示 YouTube 的“不喜欢”数量。</b><br>
+    可作为 Web 扩展程序安装到 Chrome 和 Firefox。<br>
+    也提供适用于其他浏览器的 JavaScript 用户脚本（Userscript）。<br><br>
     <img width="400px" src="https://user-images.githubusercontent.com/18729296/141743755-2be73297-250e-4cd1-ac93-8978c5a39d10.png"/>
 </p>
 
-## 专案缘起
+## 项目背景
 
-2021 年 11 月 10 日，Google [宣布](https://blog.youtube/news-and-events/update-to-youtube/) 将移除 YouTube 的不喜欢数量显示。
+2021 年 11 月 10 日，Google [宣布](https://blog.youtube/news-and-events/update-to-youtube/) YouTube 将移除“不喜欢”数量。
 
-随后，YouTube API 中的 `dislike` 字段于 2021 年 12 月 13 日 [正式移除](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts)，这使得用户无法在观看影片前通过不喜欢数评估内容质量。本专案即在此背景下诞生。
+此外，YouTube API 中的 `dislike` 字段也于 2021 年 12 月 13 日[被移除](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts)，导致用户无法在观看视频前判断内容质量。
 
-## 它是如何工作的
+## 工作原理
 
-由于 YouTube API 不再提供不喜欢统计信息，我们的后端改用了混合数据模型，结合了扩展收集的真实用户数据与估算模型来呈现不喜欢数量。
+YouTube API 移除“不喜欢”统计数据后，我们的后端改为结合抓取到的“不喜欢”统计数据，以及根据扩展程序用户数据推算出的估计值。
 
-[常见问题解答](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQcn.md)
+[常见问题](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQcn.md)
 
-## 了解更多
+## 为什么这很重要
 
-你可以在我们的官网了解更多信息：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
+如需了解更多信息，请访问我们的网站：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
 
 ## API 文档
 
-本专案允许第三方使用此公开 API，使用需遵循以下限制：
+允许第三方使用此开放 API，但须遵守以下限制：
 
-- **来源标示 (Attribution)**: 若使用本 API，请务必于明显处注明来源：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)。
-- **速率限制**: 客户端限制为每分钟 100 次、每日 10,000 次。若超过限制，API 将回传 `429` 状态码，表示请求过于频繁，请降低呼叫频率。
+- **来源标注**：使用时必须明确标注本项目，并链接至 [returnyoutubedislike.com](https://returnyoutubedislike.com/)。
+- **速率限制**：每个客户端每分钟最多请求 100 次、每天最多请求 10,000 次。超出限制时会返回 _429_ 状态码，表示您的应用应降低请求频率。
 
-可透过以下 Base URL 呼叫 API：
+可通过以下基础 URL 访问 API：
 https://returnyoutubedislikeapi.com
 
-详细 API 端点清单请参阅 [此处](https://returnyoutubedislikeapi.com/swagger/index.html)。
+可用端点列表：
+https://returnyoutubedislikeapi.com/swagger/index.html
 
 ### 获取投票数据
 
-若要获取特定 YouTube 视频 ID 的投票数据，请呼叫以下端点：
+以下示例用于获取指定 YouTube 视频 ID 的投票数据：
 `/votes?videoId=kxOuG8jMIgI`
 
 ```json
 {
   "id": "kxOuG8jMIgI",
-  "dateCreated": "2021-12-20T12:25:54.418014Z",
-  "likes": 27326,
-  "dislikes": 498153,
-  "rating": 1.212014408444885,
-  "viewCount": 3149885,
+  "dateCreated": "2022-04-09T21:44:20.5103Z",
+  "likes": 31885,
+  "rawDislikes": 31946,
+  "rawLikes": 457,
+  "dislikes": 579721,
+  "rating": 1.2085329444119253,
+  "viewCount": 3762293,
   "deleted": false
 }
 ```
 
-若 YouTube ID 不存在，API 将回传 404 状态码 (Not Found)。
-若 YouTube ID 格式错误，API 将回传 400 状态码 (Bad Request)。
+如果 YouTube ID 不存在，将返回 _404_ “Not Found” 状态码。<br>
+如果 YouTube ID 格式不正确，将返回 _400_ “Bad Request” 状态码。
+
+<!---
+## API 文档
+
+您可以在我们的网站上查看完整文档。
+[https://returnyoutubedislike.com/docs/](https://returnyoutubedislike.com/docs/) -->
 
 ## 贡献
 
-请阅读 [贡献指南](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGcn.md)。
+请阅读[贡献指南](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGcn.md)。
 
-## 支持本专案！
+## 支持本项目！
 
-您可以通过以下链接向我们捐赠来支持这个专案：
+您可以通过下方链接捐款支持本项目：
 
-[捐赠](https://returnyoutubedislike.com/donate)
+[捐款](https://returnyoutubedislike.com/donate)
 
-## 赞助商
-[成为我们的赞助商，您的信息将在我们的资源库和网站上展示。](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)
+## 赞助者
+
+[成为我们的赞助者，即可在本仓库和官方网站上展示](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEcn.md
+++ b/READMEcn.md
@@ -7,49 +7,48 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 
 <p align="center">
-    <b>Return YouTube Dislike是一个开源的扩展，可以显示 YouTube 的不喜欢数量。</b><br>
-    适用于 Chrome 和 Firefox 作为 Web 扩展。<br>
-    也可以作为 JS Userscript 在其他浏览器上使用。<br><br>
+    <b>Return YouTube Dislike 是一个开源的浏览器扩展，用于显示 YouTube 影片的不喜欢数量。</b><br>
+    适用于 Chrome 和 Firefox 等主流浏览器。<br>
+    同时也提供 JS Userscript 版本，可在其他浏览器上使用。<br><br>
     <img width="400px" src="https://user-images.githubusercontent.com/18729296/141743755-2be73297-250e-4cd1-ac93-8978c5a39d10.png"/>
 </p>
 
-## 故事
+## 专案缘起
 
-在2021年11月10日，Google [宣布](https://blog.youtube/news-and-events/update-to-youtube/) 将移除 YouTube 的不喜欢数量。
+2021 年 11 月 10 日，Google [宣布](https://blog.youtube/news-and-events/update-to-youtube/) 将移除 YouTube 的不喜欢数量显示。
 
-此外，YouTube API 中的 `dislike` 字段于2021年12月13日 [被移除](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts)，移除了在观看之前评估内容质量的能力。
+随后，YouTube API 中的 `dislike` 字段于 2021 年 12 月 13 日 [正式移除](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts)，这使得用户无法在观看影片前通过不喜欢数评估内容质量。本专案即在此背景下诞生。
 
 ## 它是如何工作的
 
-随着 YouTube API 中不喜欢统计信息的移除，我们的后端切换到使用从扩展用户数据中抓取的不喜欢统计信息和估算数据的组合。
+由于 YouTube API 不再提供不喜欢统计信息，我们的后端改用了混合数据模型，结合了扩展收集的真实用户数据与估算模型来呈现不喜欢数量。
 
 [常见问题解答](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQcn.md)
 
-## 为什么重要
+## 了解更多
 
-您可以在我们的网站上了解更多信息：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
+你可以在我们的官网了解更多信息：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
 
 ## API 文档
 
-允许第三方使用此开放 API，但有以下限制：
+本专案允许第三方使用此公开 API，使用需遵循以下限制：
 
-- **归因**: 该项目应清楚地归因于 [returnyoutubedislike.com](https://returnyoutubedislike.com/) 的链接。
-- **速率限制**: 客户端的速率限制为每分钟100次和每天10,000次。这将返回 _429_ 状态代码，表示您的应用程序应该减速。
+- **来源标示 (Attribution)**: 若使用本 API，请务必于明显处注明来源：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)。
+- **速率限制**: 客户端限制为每分钟 100 次、每日 10,000 次。若超过限制，API 将回传 `429` 状态码，表示请求过于频繁，请降低呼叫频率。
 
-API 可以通过以下基本 URL 访问：
+可透过以下 Base URL 呼叫 API：
 https://returnyoutubedislikeapi.com
 
-可用端点列表在这里：
-https://returnyoutubedislikeapi.com/swagger/index.html
+详细 API 端点清单请参阅 [此处](https://returnyoutubedislikeapi.com/swagger/index.html)。
 
-### 获取投票
+### 获取投票数据
 
-示例获取给定 YouTube 视频 ID 的投票：
+若要获取特定 YouTube 视频 ID 的投票数据，请呼叫以下端点：
 `/votes?videoId=kxOuG8jMIgI`
 
 ```json
@@ -64,17 +63,18 @@ https://returnyoutubedislikeapi.com/swagger/index.html
 }
 ```
 
-不存在的 YouTube ID 将返回状态码 _404_ "未找到"。
-格式错误的 YouTube ID 将返回 _400_ "请求无效"。
+若 YouTube ID 不存在，API 将回传 404 状态码 (Not Found)。
+若 YouTube ID 格式错误，API 将回传 400 状态码 (Bad Request)。
 
 ## 贡献
 
-请阅读[贡献指南](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGcn.md)。
+请阅读 [贡献指南](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGcn.md)。
 
-## 支持这个项目！
+## 支持本专案！
 
-您可以通过以下链接向我们捐赠来支持这个项目：
+您可以通过以下链接向我们捐赠来支持这个专案：
 
 [捐赠](https://returnyoutubedislike.com/donate)
 
 ## 赞助商
+[成为我们的赞助商，您的信息将在我们的资源库和网站上展示。](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEda.md
+++ b/READMEda.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 
 # Return YouTube Dislike

--- a/READMEde.md
+++ b/READMEde.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 
 # Return YouTube Dislike

--- a/READMEes.md
+++ b/READMEes.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEfr.md
+++ b/READMEfr.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEgr.md
+++ b/READMEgr.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEhu.md
+++ b/READMEhu.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEid.md
+++ b/READMEid.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Baca ini dalam bahasa lain: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEja.md
+++ b/READMEja.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+他の言語で読む: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 
@@ -86,7 +86,5 @@ APIの完全なドキュメントは公式サイトを参照してください�
 [寄付](https://returnyoutubedislike.com/donate)
 
 ## スポンサー
-
-
 
 [Become our sponsor](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEja.md
+++ b/READMEja.md
@@ -6,8 +6,8 @@
 [![Issues](https://img.shields.io/github/issues/Anarios/return-youtube-dislike?style=flat&label=Issues)](https://github.com/Anarios/return-youtube-dislike/issues)
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
-別の言語: [English](README.md), [русский](READMEru.md), [Español](READMEes.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md), [Ελληνικά](READMEgr.md), [Svenska](READMEsv.md), [中文](READMEcn.md), [Polski](READMEpl.md), [Danish](READMEda.md), [العربية](READMEar.md), [Bahasa Indonesia](READMEid.md), [български](READMEbg.md), [Tiếng Việt](READMEvi.md)
+
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEkr.md
+++ b/READMEkr.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+다른 언어로 읽기: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 
@@ -23,6 +23,7 @@ Read this in other languages: [English](README.md), [العربية](READMEar.md
 2021년 11월 10일, Google은 YouTube 싫어요 수를 [삭제한다고 발표](https://blog.youtube/news-and-events/update-to-youtube/)했습니다.
 
 또한, 2021년 12월 13일에 Youtube API 에서 `dislike` 필드가 [제거](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts)되어 영상을 시청하기 전에 콘텐츠의 품질을 판단할 수 있는 기능이 삭제되었습니다.
+
 ## 무엇을 하나요?
 
 YouTube API에서 dislike 통계가 제거되면서 백엔드는 스크래핑된 싫어요 통계와 확장 프로그램 사용자 데이터에서 추정한 추정치를 조합하여 사용하도록 전환했습니다.
@@ -37,7 +38,7 @@ YouTube API에서 dislike 통계가 제거되면서 백엔드는 스크래핑된
 
 다음 제한 사항 하에 서드파티 앱에서 이 Open API를 사용하는 것을 허용합니다.
 
-- **출처**: 서드파티 앱은 [returnyoutubedislike.com](https://returnyoutubedislike.com/) 링크와 함께 명확히 출처를 표시해야 합니다. 
+- **출처**: 서드파티 앱은 [returnyoutubedislike.com](https://returnyoutubedislike.com/) 링크와 함께 명확히 출처를 표시해야 합니다.
 - **Rate Limiting**: 클라이언트당 분당 100개, 하루 당 10,000개의 요청 제한이 있습니다. 하루 할당량 초과 시, 서버에서 429 에러를 반환합니다.
 
 아래 Base URL 을 통해 API에 접근할 수 있습니다:  
@@ -64,7 +65,7 @@ https://returnyoutubedislikeapi.com/swagger/index.html
 ```
 
 존재하지 않는 YouTube ID는 상태 코드 _404_ "Not Found" 를 반환합니다.<br>
-잘못 구성된 YouTube ID는 상태 코드  _400_ "Bad Request" 를 반환합니다.
+잘못 구성된 YouTube ID는 상태 코드 _400_ "Bad Request" 를 반환합니다.
 
 <!---
 ## API documentation
@@ -83,6 +84,5 @@ You can view all documentation on our website.
 [후원하기](https://returnyoutubedislike.com/donate)
 
 ## 스폰서
-
 
 [우리의 스폰서가 되어주세요](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEkr.md
+++ b/READMEkr.md
@@ -6,8 +6,9 @@
 [![Issues](https://img.shields.io/github/issues/Anarios/return-youtube-dislike?style=flat&label=Issues)](https://github.com/Anarios/return-youtube-dislike/issues)
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
-다른 언어로 전환: [English](README.md), [русский](READMEru.md), [Español](READMEes.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md), [Ελληνικά](READMEgr.md), [Svenska](READMEsv.md), [中文](READMEcn.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [Magyar](READMEhu.md), [Danish](READMEda.md)
+
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+
 # Return YouTube Dislike
 
 <p align="center">

--- a/READMEnl.md
+++ b/READMEnl.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEpl.md
+++ b/READMEpl.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEpt_BR.md
+++ b/READMEpt_BR.md
@@ -6,9 +6,8 @@
 [![Issues](https://img.shields.io/github/issues/Anarios/return-youtube-dislike?style=flat&label=Issues)](https://github.com/Anarios/return-youtube-dislike/issues)
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
-Leia isso em outros idiomas: [русский](READMEru.md), [Español](READMEes.md), [Nederlands](READMEnl.md), [Français](READMEfr.md), [日本語](READMEja.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Deutsch](READMEde.md), [Ελληνικά](READMEgr.md), [Svenska](READMEsv.md), [中文](READMEcn.md), [Polski](READMEpl.md), [Danish](READMEda.md), [العربية](READMEar.md) ou [English (Para Melhor precisão!)](README.md), [Bahasa Indonesia](READMEid.md)
 
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEpt_BR.md
+++ b/READMEpt_BR.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Leia em outros idiomas: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 
@@ -64,6 +64,7 @@ Exemplo de como obter os dados de likes e dislikes com base no ID do vídeo do Y
   "deleted": false
 }
 ```
+
 Um ID de YouTube inexistente retornará o código de status _404_ "Não Encontrado".  
 Um ID de YouTube malformado retornará o código _400_ "Requisição Inválida".
 

--- a/READMEru.md
+++ b/READMEru.md
@@ -7,8 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
-
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 # Return YouTube Dislike
 
 <p align="center">

--- a/READMEru.md
+++ b/READMEru.md
@@ -8,6 +8,7 @@
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
 Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+
 # Return YouTube Dislike
 
 <p align="center">
@@ -83,7 +84,5 @@ https://returnyoutubedislikeapi.com/swagger/index.html
 [Пожертвовать](https://returnyoutubedislike.com/donate)
 
 ## Спонсоры
-
-
 
 [Станьте нашим спонсором](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEsv.md
+++ b/READMEsv.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEtr.md
+++ b/READMEtr.md
@@ -6,8 +6,8 @@
 [![Issue'lar](https://img.shields.io/github/issues/Anarios/return-youtube-dislike?style=flat&label=Issues)](https://github.com/Anarios/return-youtube-dislike/issues)
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![Lisans](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
-Bunu diğer dillerde okuyun: [English](README.md), [русский](READMEru.md), [Español](READMEes.md), [Français](READMEfr.md), [Nederlands](READMEnl.md), [日本語](READMEja.md), [українська](READMEuk.md), [Deutsch](READMEde.md), [Ελληνικά](READMEgr.md), [Svenska](READMEsv.md), [中文](READMEcn.md), [Polski](READMEpl.md), [Magyar](READMEhu.md), [Danish](READMEda.md), [العربية](READMEar.md), [Bahasa Indonesia](READMEid.md), [български](READMEbg.md), [Tiếng Việt](READMEvi.md)
+
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # YouTube Dislike Sayısını Geri Getir
 

--- a/READMEtr.md
+++ b/READMEtr.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![Lisans](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Bunu diğer dillerde okuyun: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # YouTube Dislike Sayısını Geri Getir
 
@@ -84,7 +84,5 @@ Aşağıdaki bağlantıdan bize bağış yapabilir ve bu projeye destek olabilir
 [Bağış Yap](https://returnyoutubedislike.com/donate)
 
 ## Sponsorlar
-
-
 
 [Sponsorumuz olun](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEtw.md
+++ b/READMEtw.md
@@ -7,75 +7,84 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+閱讀其他語言版本：[English](README.md)、[العربية](READMEar.md)、[Azərbaycan dili](READMEaz.md)、[български](READMEbg.md)、[繁體中文](READMEtw.md)、[简体中文](READMEcn.md)、[Danish](READMEda.md)、[Deutsch](READMEde.md)、[Español](READMEes.md)、[Français](READMEfr.md)、[Ελληνικά](READMEgr.md)、[Magyar](READMEhu.md)、[Bahasa Indonesia](READMEid.md)、[日本語](READMEja.md)、[한국어](READMEkr.md)、[Nederlands](READMEnl.md)、[Polski](READMEpl.md)、[Português do Brasil](READMEpt_BR.md)、[русский](READMEru.md)、[Svenska](READMEsv.md)、[Türkçe](READMEtr.md)、[українська](READMEuk.md)、[Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 
 <p align="center">
-    <b>Return YouTube Dislike 是一個開源的瀏覽器擴充功能，可以顯示 Youtube 的不喜歡數量。</b><br>
-    適用於 Chrome 和 Firefox 作為 Web 擴充功能。<br>
-    也可以作為 JS Userscript 在其他瀏覽器上使用。<br><br>
+    <b>Return YouTube Dislike 是一款開放原始碼的瀏覽器擴充功能，可恢復顯示 YouTube 的不喜歡數。</b><br>
+    可作為 Web 擴充功能安裝於 Chrome 與 Firefox。<br>
+    也提供適用於其他瀏覽器的 JavaScript 使用者腳本（Userscript）。<br><br>
     <img width="400px" src="https://user-images.githubusercontent.com/18729296/141743755-2be73297-250e-4cd1-ac93-8978c5a39d10.png"/>
 </p>
 
-## 背景
+## 緣起
 
-在2021年11月10日，Google [宣布](https://blog.youtube/news-and-events/update-to-youtube/) 將會移除 YouTube 的不喜歡數量。
+2021 年 11 月 10 日，Google [宣布](https://blog.youtube/news-and-events/update-to-youtube/) YouTube 將移除不喜歡數。
 
-此外，YouTube API 中的 `dislike` 欄位於2021年12月13日 [被移除](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts)，移除了在觀看影片之前評估內容品質的依據。
+此外，YouTube API 中的 `dislike` 欄位也於 2021 年 12 月 13 日[遭到移除](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts)，讓使用者無法在觀看影片前判斷內容品質。
 
-## 它是如何運作的
+## 運作方式
 
-由於 YouTube API 不再提供不喜歡統計，我們的後端改為混合使用擴充功能所回傳的用戶數據，並配合估算模型來呈現不喜歡數量。
+YouTube API 移除不喜歡統計資料後，我們的後端改為結合擷取到的不喜歡統計資料，以及根據擴充功能使用者資料推算出的估計值。
 
-[常見問題解答](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQcn.md)
+[常見問題（簡體中文）](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQcn.md)
 
-## 了解更多
+## 重要性
 
-你可以在我們的網站上了解更多資訊：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
+如需進一步瞭解，請造訪我們的網站：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
 
 ## API 文件
 
-本專案允許第三方使用此公開 API，但有以下限制：
+第三方可以使用這個開放 API，但須遵守以下限制：
 
-### 來源標示
-- **標示出處**:　若使用本 API，請務必於明顯處註明來源：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)。
-- **速率限制**: 客户端的速率限制為每分鐘100次和每天10,000次。如果回傳 _429_ 狀態代碼，表示客戶端請求過於頻繁，請降低呼叫頻率。
+- **標示來源**：使用時必須清楚標示本專案，並連結至 [returnyoutubedislike.com](https://returnyoutubedislike.com/)。
+- **速率限制**：每個用戶端每分鐘最多 100 次、每天最多 10,000 次。超過限制時會傳回 _429_ 狀態碼，表示您的應用程式應降低請求頻率。
 
-可以通過這個基本 URL 呼叫 API：
+可透過下列基礎 URL 使用 API：
 https://returnyoutubedislikeapi.com
 
-詳細 API 端點清單請參閱 [此處](https://returnyoutubedislikeapi.com/swagger/index.html)
+可用端點清單：
+https://returnyoutubedislikeapi.com/swagger/index.html
 
-### 取得投票數據
+### 取得投票數
 
-若要取得特定 YouTube 影片 ID 的投票數據，請呼叫以下端點：
+以下範例可取得指定 YouTube 影片 ID 的投票數：
 `/votes?videoId=kxOuG8jMIgI`
 
 ```json
 {
   "id": "kxOuG8jMIgI",
-  "dateCreated": "2021-12-20T12:25:54.418014Z",
-  "likes": 27326,
-  "dislikes": 498153,
-  "rating": 1.212014408444885,
-  "viewCount": 3149885,
+  "dateCreated": "2022-04-09T21:44:20.5103Z",
+  "likes": 31885,
+  "rawDislikes": 31946,
+  "rawLikes": 457,
+  "dislikes": 579721,
+  "rating": 1.2085329444119253,
+  "viewCount": 3762293,
   "deleted": false
 }
 ```
 
-若該 YouTube ID 不存在，API 將回傳 404 狀態碼（Not Found）。
-若 YouTube ID 格式錯誤，API 將回傳 400 狀態碼（Bad Request）。
+不存在的 YouTube ID 會傳回 _404_「Not Found」狀態碼。<br>
+格式不正確的 YouTube ID 會傳回 _400_「Bad Request」狀態碼。
+
+<!---
+## API 文件
+
+您可以在我們的網站上查看完整文件。
+[https://returnyoutubedislike.com/docs/](https://returnyoutubedislike.com/docs/) -->
 
 ## 貢獻
 
-請閱讀[貢獻指南](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGcn.md)。
+請閱讀[貢獻指南（簡體中文）](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGcn.md)。
 
 ## 支持本專案！
 
-你可以透過以下超連結向我們捐款以支持本專案：
+您可以透過下方連結捐款支持本專案：
 
 [捐款](https://returnyoutubedislike.com/donate)
 
-## 贊助我們
-[贊助本專案，您的資訊將會顯示於我們的資源庫與官方網站。](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)
+## 贊助者
+
+[成為我們的贊助者，即可在本儲存庫與官方網站上展示](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEtw.md
+++ b/READMEtw.md
@@ -12,43 +12,44 @@ Read this in other languages: [English](README.md), [العربية](READMEar.md
 # Return YouTube Dislike
 
 <p align="center">
-    <b>Return Youtube Dislike adalah extension open-source yang memunculkan jumlah dislike di Youtube.<br>
-    Juga ada pada browser lain sebagai JS Userscript.<br><br>
+    <b>Return YouTube Dislike 是一個開源的瀏覽器擴充功能，可以顯示 Youtube 的不喜歡數量。</b><br>
+    適用於 Chrome 和 Firefox 作為 Web 擴充功能。<br>
+    也可以作為 JS Userscript 在其他瀏覽器上使用。<br><br>
     <img width="400px" src="https://user-images.githubusercontent.com/18729296/141743755-2be73297-250e-4cd1-ac93-8978c5a39d10.png"/>
 </p>
 
-## Latar Belakang
+## 背景
 
-Pada 10 November 2021, Google [memberitakan](https://blog.youtube/news-and-events/update-to-youtube/) bahwa jumlah dislike di Youtube akan dihapus.
+在2021年11月10日，Google [宣布](https://blog.youtube/news-and-events/update-to-youtube/) 將會移除 YouTube 的不喜歡數量。
 
-Serta, data `dislike` pada API Youtube juga [dihapus](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts) pada 13 Desember 2021, sehingga menghilangkan kemampuan untuk menilai qualitas konten video sebelum ditonton.
+此外，YouTube API 中的 `dislike` 欄位於2021年12月13日 [被移除](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts)，移除了在觀看影片之前評估內容品質的依據。
 
-## Apa yang terjadi
+## 它是如何運作的
 
-Dengan dihapusnya data dislike dari API Youtube, kami mengubah backend kami sehingga menggunakan kombinasi scraping data dislike, dan estimasi perkiraan dari data pengguna.
+由於 YouTube API 不再提供不喜歡統計，我們的後端改為混合使用擴充功能所回傳的用戶數據，並配合估算模型來呈現不喜歡數量。
 
-[Pertanyaan yang Sering Ditanyakan](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQid.md)
+[常見問題解答](https://github.com/Anarios/return-youtube-dislike/blob/main/Docs/FAQcn.md)
 
-## Mengapa ini Penting
+## 了解更多
 
-Kamu bisa mempelajari lebih lanjut pada website kami di: [returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
+你可以在我們的網站上了解更多資訊：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)
 
-## Dokumentasi API
+## API 文件
 
-Penggunaan pada pihak ketiga terhadap API ini diizinkan dengan beberapa batasan berikut:
+本專案允許第三方使用此公開 API，但有以下限制：
 
-- **Pereferensian**: Proyek ini harus jelas direferensikan menggunakan link ke [returnyoutubedislike.com](https://returnyoutubedislike.com/).
-- **Batas Penggunaan**: Terdapat batas penggunaan pada setiap client yaitu 100 per menit dan 10,000 per hari. Jika lebih dari ini, akan ada kode status _429_ yang menandakan kamu harus berhenti menggunakannya.
+### 來源標示
+- **標示出處**:　若使用本 API，請務必於明顯處註明來源：[returnyoutubedislike.com](https://www.returnyoutubedislike.com/)。
+- **速率限制**: 客户端的速率限制為每分鐘100次和每天10,000次。如果回傳 _429_ 狀態代碼，表示客戶端請求過於頻繁，請降低呼叫頻率。
 
-APInya bisa diakses melalui URL berikut:
+可以通過這個基本 URL 呼叫 API：
 https://returnyoutubedislikeapi.com
 
-Daftar semua endpoint yang ada:
-https://returnyoutubedislikeapi.com/swagger/index.html
+詳細 API 端點清單請參閱 [此處](https://returnyoutubedislikeapi.com/swagger/index.html)
 
-### Voting
+### 取得投票數據
 
-Contoh untuk melakukan voting terhadap suatu video Youtube menggunakan id:
+若要取得特定 YouTube 影片 ID 的投票數據，請呼叫以下端點：
 `/votes?videoId=kxOuG8jMIgI`
 
 ```json
@@ -63,25 +64,18 @@ Contoh untuk melakukan voting terhadap suatu video Youtube menggunakan id:
 }
 ```
 
-Akan muncul kode status _404_ "Not Found" jika Youtube id tidak ditemukan.
-Akan muncul kode status _400_ "Bad Request" jika Youtube id memiliki format yang salah.
+若該 YouTube ID 不存在，API 將回傳 404 狀態碼（Not Found）。
+若 YouTube ID 格式錯誤，API 將回傳 400 狀態碼（Bad Request）。
 
-<!---
-## API documentation
+## 貢獻
 
-You can view all documentation on our website.
-[https://returnyoutubedislike.com/documentation/](https://returnyoutubedislike.com/documentation/) -->
+請閱讀[貢獻指南](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGcn.md)。
 
-## Kontribusi
+## 支持本專案！
 
-Tolong baca [panduan kontribusi](https://github.com/Anarios/return-youtube-dislike/blob/main/CONTRIBUTINGid.md).
+你可以透過以下超連結向我們捐款以支持本專案：
 
-## Dukung proyek ini!
+[捐款](https://returnyoutubedislike.com/donate)
 
-Kamu dapat mendukung proyek ini dengan cara donasi melalui link dibawah ini:
-
-[Donasi](https://returnyoutubedislike.com/donate)
-
-## Sponsor
-
-[Menjadi sponsor kami](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)
+## 贊助我們
+[贊助本專案，您的資訊將會顯示於我們的資源庫與官方網站。](https://www.patreon.com/join/returnyoutubedislike/checkout?rid=8008601)

--- a/READMEuk.md
+++ b/READMEuk.md
@@ -7,7 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![License](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike
 

--- a/READMEvi.md
+++ b/READMEvi.md
@@ -7,10 +7,7 @@
 [![Discord](https://img.shields.io/discord/909435648170160229?label=Discord&style=flat&logo=discord)](https://discord.gg/UMxyMmCgfF)
 [![Giấy phép](https://img.shields.io/badge/License-GPLv3-blue.svg?label=Giấy%20phép&style=flat)](https://github.com/Anarios/return-youtube-dislike/blob/main/LICENSE)
 
-
-Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
-
-
+Read this in other languages: [English](README.md), [العربية](READMEar.md), [Azərbaycan dili](READMEaz.md), [български](READMEbg.md), [繁體中文](READMEtw.md), [简体中文](READMEcn.md), [Danish](READMEda.md), [Deutsch](READMEde.md), [Español](READMEes.md), [Français](READMEfr.md), [Ελληνικά](READMEgr.md), [Magyar](READMEhu.md), [Bahasa Indonesia](READMEid.md), [日本語](READMEja.md), [한국어](READMEkr.md), [Nederlands](READMEnl.md), [Polski](READMEpl.md), [Português do Brasil](READMEpt_BR.md), [русский](READMEru.md), [Svenska](READMEsv.md), [Türkçe](READMEtr.md), [українська](READMEuk.md), [Tiếng Việt](READMEvi.md)
 
 # Return YouTube Dislike (Trả lại số lượt Không thích trên YouTube)
 


### PR DESCRIPTION
## Description
This PR introduces the Traditional Chinese (zh-TW) translation for the README and performs a cleanup of the language selection lists across all existing README files.

### Changes:
- **New Translation**: Added `READMEtw.md` to support Traditional Chinese users.
- **Language List Cleanup**: 
  - Standardized the language selection lists across all files (`README.md` and all `READMExx.md` variants).
  - Resolved redundant/duplicate language lists found in `READMEid.md`, `READMEja.md`, `READMEkr.md`, and `READMEtr.md`.
  - Ensured all language lists now consistently include the new Traditional Chinese version.
- **Content Refinement**: Updated `READMEcn.md` to maintain consistency and professional tone.

This contribution aims to improve accessibility for Chinese-speaking users and maintain better documentation quality across the repository.