### PR TITLE
fix: add fallback color to ryd-bar

### DIFF
--- a/Extensions/combined/content-style.css
+++ b/Extensions/combined/content-style.css
@@ -25,7 +25,7 @@
 }
 
 #ryd-bar {
-  background: var(--yt-spec-text-primary);
+  background: var(--yt-spec-text-primary, #f1f1f1);
   border-radius: 2px;
   transition: all 0.15s ease-in-out;
 }


### PR DESCRIPTION
## fixes #1320 

The ryd-bar didn't have a fallback color unlike its container which made the color transparent if youtube didn't define the variable. I added a fallback to #f1f1f1.